### PR TITLE
fix: import existing container app

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -194,6 +194,14 @@ module "acr" {
 # ---------------------------------------------------------------------------
 # Container App Environment + Container App
 # ---------------------------------------------------------------------------
+# Import existing Container App into state when it was created out-of-band.
+# Remove this block after a successful apply.
+# ---------------------------------------------------------------------------
+import {
+  to = module.container_app.azurerm_container_app.app
+  id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.main.name}/providers/Microsoft.App/containerApps/ca-${local.app_name}-${var.env}"
+}
+
 module "container_app" {
   source = "../../modules/container_app"
 


### PR DESCRIPTION
## Summary
- import the existing dev Container App into Terraform state to unblock applies

## Why/Context
- the workflow failed because the Container App already exists and Terraform attempted to create it

## Changes
- add an `import` block in `infra/environments/dev/main.tf` for `ca-bankapi-dev`

## Validation
- `pip install -r requirements.txt`
- `pylint src/`
- `pytest tests/ --cov=src --cov-report=term-missing --cov-fail-under=85`
- `docker build -t bankapi .`
- `trivy image --exit-code 1 --severity HIGH,CRITICAL bankapi` (failed: 6 HIGH OS vulns in base image)

## Risks and rollback
- Low risk: import only. Rollback by removing the import block after apply if undesired.
