### PR TITLE
fix: enforce infra-first release sequencing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,9 @@
 name: CD
 
+# Deployment orchestration is infra-first for every environment.
+# Dev deploys automatically after successful dev infra apply.
+# Prod deploys only after approved prod infra promotion succeeds.
+
 on:
   workflow_run:
     workflows: ["Terraform Infra Apply Dev", "Terraform Infra Apply Prod"]
@@ -14,7 +18,15 @@ jobs:
   prepare:
     name: Resolve image tag
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        (
+          github.event.workflow_run.event == 'push' ||
+          (github.event.workflow_run.name == 'Terraform Infra Apply Prod' && github.event.workflow_run.event == 'workflow_dispatch')
+        )
+      }}
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
@@ -28,7 +40,10 @@ jobs:
   deploy_dev:
     name: Deploy dev
     needs: prepare
-    if: ${{ github.event.workflow_run.name == 'Terraform Infra Apply Dev' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.name == 'Terraform Infra Apply Dev' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    concurrency:
+      group: deploy-banking-dev
+      cancel-in-progress: false
     uses: ./.github/workflows/workflow-deploy-aca-v1.0.0.yml
     with:
       resource_group_name: ${{ vars.AZURE_RESOURCE_GROUP_DEV }}
@@ -44,7 +59,16 @@ jobs:
   deploy_prod:
     name: Deploy prod
     needs: prepare
-    if: ${{ github.event.workflow_run.name == 'Terraform Infra Apply Prod' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.name == 'Terraform Infra Apply Prod' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')
+      }}
+    concurrency:
+      group: deploy-banking-prod
+      cancel-in-progress: false
     uses: ./.github/workflows/workflow-deploy-aca-v1.0.0.yml
     with:
       resource_group_name: ${{ vars.AZURE_RESOURCE_GROUP_PROD }}

--- a/.github/workflows/infra-apply-dev.yml
+++ b/.github/workflows/infra-apply-dev.yml
@@ -1,5 +1,8 @@
 name: Terraform Infra Apply Dev
 
+# Dev infra is the automatic first deployment step after mainline changes.
+# App deployment is chained from this workflow via cd.yml on successful completion.
+
 on:
   push:
     branches:
@@ -7,8 +10,6 @@ on:
     paths:
       - infra/**
       - .github/workflows/infra-apply-dev.yml
-      - .github/workflows/infra-apply-prod.yml
-      - .github/workflows/infra-terraform.yml
       - .github/workflows/cd.yml
   workflow_dispatch:
     inputs:
@@ -32,6 +33,9 @@ jobs:
     name: Apply dev
     runs-on: ubuntu-latest
     environment: banking-dev
+    concurrency:
+      group: infra-dev-${{ github.ref_name }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/infra-apply-prod.yml
+++ b/.github/workflows/infra-apply-prod.yml
@@ -1,15 +1,10 @@
 name: Terraform Infra Apply Prod
 
+# Prod infra is a promotion step.
+# It only runs by manual dispatch and relies on the banking-prod environment
+# for human approval before infrastructure changes are applied.
+
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - infra/**
-      - .github/workflows/infra-apply-dev.yml
-      - .github/workflows/infra-apply-prod.yml
-      - .github/workflows/infra-terraform.yml
-      - .github/workflows/cd.yml
   workflow_dispatch:
     inputs:
       reason:
@@ -32,6 +27,10 @@ jobs:
     name: Apply prod
     runs-on: ubuntu-latest
     environment: banking-prod
+    if: ${{ github.ref == 'refs/heads/main' }}
+    concurrency:
+      group: infra-prod-${{ github.ref_name }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/workflow-deploy-aca-v1.0.0.yml
+++ b/.github/workflows/workflow-deploy-aca-v1.0.0.yml
@@ -58,6 +58,9 @@ jobs:
   deploy-aca:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    concurrency:
+      group: deploy-${{ inputs.deployment_environment }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Enforce infra-first release sequencing for GitHub Actions deployments
- Keep dev automatic: infra apply succeeds before app deploy runs
- Make prod a manual, approval-gated promotion flow before app deploy

## Why / Context
- Dev and prod infra workflows were both auto-triggering on mainline changes, which allowed parallel environment progression
- The target model is deterministic promotion: dev auto-runs, prod requires explicit approval and then follows the same infra -> app sequence

## Changes
- Remove automatic push trigger from prod infra apply workflow
- Keep prod infra on workflow_dispatch with banking-prod environment approval
- Tighten cd.yml conditions so deploy jobs require successful upstream infra workflows
- Allow prod CD chaining from a manually dispatched successful prod infra apply run
- Add concurrency guards to infra apply and deploy workflows per environment
- Add inline workflow comments describing orchestration intent

## Validation
- Parsed updated workflow YAML files successfully with Ruby YAML loader
- Verified no editor diagnostics in the modified workflow files
- No application or Terraform runtime tests were executed because the change is limited to GitHub Actions workflow wiring

## Risks and Rollback
- Prod deployment now requires manual dispatch plus environment approval; this is intentional but changes operator workflow
- Rollback: revert this PR to restore the previous automatic prod trigger behavior
