### PR TITLE
fix: remove invalid 'variables' permission scope and align workflow YAML gates

### DIFF
--- a/.github/agents/infra-devops.agent.md
+++ b/.github/agents/infra-devops.agent.md
@@ -102,7 +102,75 @@ az containerapp revision list \
   -o table
 ```
 
-### Step 3 — Build and Security Validation (mandatory)
+### Step 3 — GitHub Actions Workflow YAML Validation (mandatory)
+
+Whenever any `.github/workflows/*.yml` file is created or modified, run this gate **before** proceeding to the build/security step. Zero errors allowed.
+
+**3a — YAML syntax and permission-scope check:**
+```bash
+python3 - <<'EOF'
+import yaml, sys, pathlib
+
+VALID_PERMISSIONS = {
+    "actions", "checks", "contents", "deployments", "discussions",
+    "id-token", "issues", "packages", "pages", "pull-requests",
+    "repository-projects", "security-events", "statuses", "workflows"
+}
+
+errors = []
+for f in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+    try:
+        doc = yaml.safe_load(f.read_text())
+        # Top-level permissions
+        perms = doc.get("permissions", {})
+        if isinstance(perms, dict):
+            invalid = set(perms) - VALID_PERMISSIONS
+            if invalid:
+                errors.append(f"{f}: invalid top-level permission scope(s): {sorted(invalid)}")
+        # Per-job permissions
+        for job_id, job in (doc.get("jobs") or {}).items():
+            jperms = job.get("permissions", {})
+            if isinstance(jperms, dict):
+                invalid = set(jperms) - VALID_PERMISSIONS
+                if invalid:
+                    errors.append(f"{f} (job '{job_id}'): invalid permission scope(s): {sorted(invalid)}")
+    except yaml.YAMLError as exc:
+        errors.append(f"{f}: YAML parse error: {exc}")
+
+if errors:
+    print("YAML validation FAILED:")
+    for e in errors:
+        print(" ", e)
+    sys.exit(1)
+print("All workflow YAML files valid.")
+EOF
+```
+
+**3b — SHA tag truncation consistency check:**
+```bash
+# Build workflow is the source of truth for the tag format used in ACR.
+# cd.yml must use the same truncation length, or deployment will get MANIFEST_UNKNOWN.
+BUILD_LEN=$(grep -oP 'GITHUB_SHA:0:\K\d+' .github/workflows/workflow-build-v1.0.0.yml 2>/dev/null | head -1)
+CD_LEN=$(grep -oP 'SHORT_SHA:0:\K\d+' .github/workflows/cd.yml 2>/dev/null | head -1)
+if [[ -z "$BUILD_LEN" || -z "$CD_LEN" ]]; then
+  echo "WARNING: Could not find SHA truncation expressions — verify manually."
+elif [[ "$BUILD_LEN" != "$CD_LEN" ]]; then
+  echo "SHA truncation MISMATCH: workflow-build uses ${BUILD_LEN} chars, cd.yml uses ${CD_LEN} chars."
+  echo "Fix cd.yml to use :0:${BUILD_LEN} so the image tag matches what was pushed to ACR."
+  exit 1
+fi
+echo "SHA truncation consistent: ${BUILD_LEN:-N/A} chars."
+```
+
+Rules:
+- Stop at the first failure; report the exact command output in your handoff notes.
+- Invalid GitHub Actions permission scopes (e.g. `variables: write`) are not recoverable at runtime — they abort the entire workflow before any job runs.
+- A SHA length mismatch causes `MANIFEST_UNKNOWN` at deploy time regardless of a successful build.
+- Never proceed to Step 4 (build/scan) if Step 3a or 3b reports an error.
+
+---
+
+### Step 4 — Build and Security Validation (mandatory)
 
 Before writing your completion report, validate image build and security scan:
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -246,6 +246,7 @@ Report the summary to the user.
 | Lint | `pylint src/` | Exit code 0 |
 | Tests | `pytest --cov=src --cov-fail-under=85` | All pass, coverage ≥ 85% |
 | Security | `trivy image bankapi` | Zero HIGH/CRITICAL |
+| Workflow YAML | Python permission-scope check + SHA consistency check (infra-devops-agent Step 3) | Zero invalid scopes; zero YAML errors; SHA truncation lengths match |
 | Deployment health | `curl /health` | HTTP 200 + `status: healthy` |
 
 If any gate fails, enter the appropriate failure path. Never skip a gate.
@@ -258,7 +259,7 @@ Treat quality validation as distributed ownership. Do not allow any run to concl
 |---|---|
 | `python-coding-agent` | `pip install -r requirements.txt`, `python -m black --check src`, `pylint src/` |
 | `unit-test-agent` | `python -m black --check tests`, `pytest tests/ --cov=src --cov-report=term-missing --cov-fail-under=85` |
-| `infra-devops-agent` | `docker build -t bankapi .`, `trivy image --exit-code 1 --severity HIGH,CRITICAL bankapi` |
+| `infra-devops-agent` | **Workflow YAML gate** (permission-scope validation + SHA truncation consistency check) — see Step 3 of infra-devops.agent.md; then `docker build -t bankapi .`, `trivy image --exit-code 1 --severity HIGH,CRITICAL bankapi` |
 | `orchestrator-agent` | Deployment health validation via `/health` and failure-loop routing |
 
 Execution rules:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,41 @@ pytest tests/ --cov=src --cov-report=term-missing --cov-fail-under=85
 
 # Docker build + security scan
 docker build -t bankapi . && trivy image --exit-code 1 --severity HIGH,CRITICAL bankapi
+
+# GitHub Actions workflow YAML validation (run whenever .github/workflows/*.yml changes)
+# 1. Permission-scope check — rejects unknown scopes (e.g. 'variables: write') that
+#    cause GitHub to abort the entire workflow before any job runs.
+python3 - <<'EOF'
+import yaml, sys, pathlib
+VALID_PERMISSIONS = {
+    "actions","checks","contents","deployments","discussions",
+    "id-token","issues","packages","pages","pull-requests",
+    "repository-projects","security-events","statuses","workflows"
+}
+errors = []
+for f in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+    try:
+        doc = yaml.safe_load(f.read_text())
+        for scope_dict in [
+            doc.get("permissions", {}),
+            *[j.get("permissions", {}) for j in (doc.get("jobs") or {}).values()]
+        ]:
+            if isinstance(scope_dict, dict):
+                bad = set(scope_dict) - VALID_PERMISSIONS
+                if bad: errors.append(f"{f}: invalid permission scope(s): {sorted(bad)}")
+    except yaml.YAMLError as e:
+        errors.append(f"{f}: YAML error: {e}")
+if errors:
+    [print(e) for e in errors]; sys.exit(1)
+print("Workflow YAML permission scopes: OK")
+EOF
+
+# 2. SHA tag consistency — build workflow is the ACR tag source of truth;
+#    cd.yml must use the same truncation length to avoid MANIFEST_UNKNOWN.
+BUILD_LEN=$(grep -oP 'GITHUB_SHA:0:\K\d+' .github/workflows/workflow-build-v1.0.0.yml 2>/dev/null | head -1)
+CD_LEN=$(grep -oP 'SHORT_SHA:0:\K\d+' .github/workflows/cd.yml 2>/dev/null | head -1)
+[ "$BUILD_LEN" = "$CD_LEN" ] && echo "SHA truncation consistent (${BUILD_LEN} chars): OK" \
+  || { echo "SHA mismatch: build=${BUILD_LEN}, cd=${CD_LEN}"; exit 1; }
 ```
 
 ## Architecture at a Glance
@@ -45,6 +80,7 @@ src/
 5. **Boundaries**: Agents own specific layers — do not cross ownership lines without explicit handoff.
 6. **Terraform Artifacts**: Never commit local Terraform runtime artifacts (`.terraform/`, `terraform.tfstate*`, `tfplan*`, `crash.log`, `*_override.tf*`). Ensure these are covered by `.gitignore` before check-in.
 7. **Infra-First Deploy Orchestration**: For GitHub Actions, infrastructure apply workflows must complete successfully before any app deployment workflow runs. Enforce this through top-level `workflow_run` dependencies (for example, CD depends on infra apply workflows), not direct CI-to-CD deployment triggering.
+8. **GitHub Actions YAML Correctness** (`infra-devops-agent` mandatory gate): Whenever a `.github/workflows/*.yml` file is created or modified, run the workflow YAML validation script (see Build & Validation Commands) before concluding the task. Two checks are required: (a) permission-scope validation — GitHub silently rejects unknown scope keys (e.g. `variables: write`) and aborts the whole workflow; valid scopes are `actions`, `checks`, `contents`, `deployments`, `discussions`, `id-token`, `issues`, `packages`, `pages`, `pull-requests`, `repository-projects`, `security-events`, `statuses`, `workflows`; (b) SHA truncation consistency — the image tag length in `cd.yml` must match `workflow-build-v1.0.0.yml` or deployment will fail with `MANIFEST_UNKNOWN`.
 
 ## Layer Ownership
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         id: set-tag
         run: |
           SHORT_SHA="${{ github.event.workflow_run.head_sha }}"
-          SHORT_SHA="${SHORT_SHA:0:12}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
           echo "image_tag=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
   deploy_dev:

--- a/.github/workflows/infra-apply-dev.yml
+++ b/.github/workflows/infra-apply-dev.yml
@@ -22,7 +22,6 @@ permissions:
   contents: read
   id-token: write
   actions: write
-  variables: write
 
 env:
   TF_VERSION: "1.9.8"

--- a/.github/workflows/infra-apply-prod.yml
+++ b/.github/workflows/infra-apply-prod.yml
@@ -17,7 +17,6 @@ permissions:
   contents: read
   id-token: write
   actions: write
-  variables: write
 
 env:
   TF_VERSION: "1.9.8"


### PR DESCRIPTION
## Summary

Fixes two recurring pipeline failures and codifies the checks as mandatory agent gates so they cannot regress.

## Problems Fixed

### 1. `Unexpected value 'variables'` — workflow parse error

`infra-apply-prod.yml` and `infra-apply-dev.yml` contained `variables: write` in their `permissions` block. `variables` is not a valid GitHub Actions permission scope. GitHub's YAML parser rejects the entire workflow file before any job runs, so no Terraform apply could ever execute from these files.

### 2. `MANIFEST_UNKNOWN` — image tag not found in ACR

`cd.yml` `prepare` job truncated the commit SHA to **12 characters** (`sha-84b8a9503445`) while `workflow-build-v1.0.0.yml` pushes images with a **7-character** SHA (`sha-84b8a95`). The tag looked for at deploy time did not exist in ACR.

## Changes

| File | Change |
|---|---|
| `.github/workflows/infra-apply-prod.yml` | Remove `variables: write` from `permissions` |
| `.github/workflows/infra-apply-dev.yml` | Remove `variables: write` from `permissions` |
| `.github/workflows/cd.yml` | Fix SHA truncation `:0:12` → `:0:7` |
| `.github/agents/infra-devops.agent.md` | Add mandatory Step 3: YAML validation gate (permission-scope check + SHA consistency check) before build/trivy |
| `.github/agents/orchestrator.agent.md` | Add Workflow YAML row to Quality Gates table; update Agent-Owned Responsibilities |
| `.github/copilot-instructions.md` | Add YAML validation scripts to Build & Validation Commands; add Rule 8 (GitHub Actions YAML Correctness) to Non-Negotiable Rules |

## Validation

Permission-scope check — all `.github/workflows/*.yml` files now pass the Python validator.

SHA consistency check — `workflow-build-v1.0.0.yml` and `cd.yml` both use 7-character SHA truncation.

## Risks & Rollback

- Removing an invalid permission scope is a no-op for runtime — the permissions were never applied by GitHub.
- SHA truncation change is safe — images in ACR from the build workflow are already tagged with 7-char SHAs; aligning CD restores correct resolution.
- Rollback: `git revert` this commit.
