### PR TITLE
fix: workflow guardrails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,27 @@ jobs:
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
+      - name: Ensure CI succeeded for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          api_url="https://api.github.com/repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&event=push&status=completed&per_page=100"
+          ci_success_count="$(
+            curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "${api_url}" |
+            jq '[.workflow_runs[] | select(.name == "CI" and .conclusion == "success")] | length'
+          )"
+
+          if [[ "${ci_success_count}" -lt 1 ]]; then
+            echo "::error::No successful CI run found for commit '${HEAD_SHA}'."
+            echo "::error::Deployment is blocked because the image may not have been built/pushed."
+            exit 1
+          fi
+
+          echo "Found successful CI run for commit '${HEAD_SHA}'."
+
       - name: Compute image tag
         id: set-tag
         run: |

--- a/.github/workflows/infra-apply-dev.yml
+++ b/.github/workflows/infra-apply-dev.yml
@@ -125,7 +125,6 @@ jobs:
         run: terraform apply -input=false -auto-approve tfplan
 
       - name: Export Terraform outputs to GitHub repository variables (dev)
-        continue-on-error: true
         working-directory: infra/environments/dev
         env:
           ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
@@ -137,7 +136,7 @@ jobs:
           RG=$(terraform output -raw resource_group_name)
           CA=$(terraform output -raw container_app_name)
           ACR=$(terraform output -raw acr_login_server)
-          gh variable set AZURE_RESOURCE_GROUP_DEV --body "$RG" --repo "$GITHUB_REPOSITORY" || echo "::warning::Unable to set AZURE_RESOURCE_GROUP_DEV repository variable."
-          gh variable set CONTAINER_APP_NAME_DEV --body "$CA" --repo "$GITHUB_REPOSITORY" || echo "::warning::Unable to set CONTAINER_APP_NAME_DEV repository variable."
-          gh variable set ACR_LOGIN_SERVER_DEV --body "$ACR" --repo "$GITHUB_REPOSITORY" || echo "::warning::Unable to set ACR_LOGIN_SERVER_DEV repository variable."
+          gh variable set AZURE_RESOURCE_GROUP_DEV --body "$RG" --repo "$GITHUB_REPOSITORY"
+          gh variable set CONTAINER_APP_NAME_DEV --body "$CA" --repo "$GITHUB_REPOSITORY"
+          gh variable set ACR_LOGIN_SERVER_DEV --body "$ACR" --repo "$GITHUB_REPOSITORY"
           echo "Exported dev deployment variables: RG=${RG}, CA=${CA}, ACR=${ACR}"

--- a/.github/workflows/workflow-build-v1.0.0.yml
+++ b/.github/workflows/workflow-build-v1.0.0.yml
@@ -95,6 +95,19 @@ jobs:
           name: release-stamp
           path: release-stamp.json
 
+      - name: Validate image publish inputs
+        if: ${{ inputs.container_image_repository != '' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ inputs.container_registry_url }}" ]]; then
+            echo "::error::Image publish requested but 'container_registry_url' is empty. Set ACR_LOGIN_SERVER_DEV before running CI."
+            exit 1
+          fi
+          if [[ -z "${{ secrets.registry_username }}" || -z "${{ secrets.registry_password }}" ]]; then
+            echo "::error::Image publish requested but registry credentials are missing. Configure ACR_USERNAME and ACR_PASSWORD secrets."
+            exit 1
+          fi
+
       - name: Create Traceable Image Tag
         if: ${{ inputs.container_registry_url != '' && inputs.container_image_repository != '' }}
         run: |


### PR DESCRIPTION
## Summary
Add workflow guardrails to reduce accidental deployments and improve failure visibility.

## Why / Context
- CD should not run for a commit unless CI completed successfully for that same SHA.
- Infra apply should fail loudly if exporting deployment variables fails.
- Build workflow should fail early when image publish inputs/credentials are missing.

## Changes
- **cd.yml**: verify at least one successful **CI** run exists for `head_sha` before proceeding.
- **infra-apply-dev.yml**: remove `continue-on-error` and stop swallowing failures when setting repo variables.
- **workflow-build-v1.0.0.yml**: validate publish inputs/credentials before attempting to publish an image.

## Validation
- Workflow YAML permission scopes: OK
- SHA truncation consistent between build and CD: OK

## Risks / Rollback
- Infra apply may fail more often if repo variable permissions aren’t correctly configured (intended).
- Rollback: revert this PR to restore prior permissive behavior.
