### PR TITLE
fix: enforce PR checks and main dev release sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,7 @@
 name: CI
 
+# Legacy workflow kept for manual fallback. Main merge deployments are orchestrated by main-dev-release.yml.
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths-ignore:
-      - '**/*.md'
-      - '.pipelines/variables/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -7,18 +7,6 @@ on:
     paths:
       - infra/**
       - .github/workflows/infra-terraform.yml
-      - .github/workflows/infra-apply-dev.yml
-      - .github/workflows/cd.yml
-      - .github/workflows/workflow-deploy-aca-v1.0.0.yml
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: Target environment
-        required: true
-        type: choice
-        options:
-          - dev
-        default: dev
 
 permissions:
   contents: read
@@ -31,13 +19,8 @@ env:
 
 jobs:
   plan_dev:
-    name: Plan dev
+    name: Lint, Validate, and Plan Terraform
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && inputs.environment == 'dev')
-      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,4 +110,12 @@ jobs:
           ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform plan -input=false -no-color -var-file=terraform.tfvars
+
+      - name: Run Trivy IaC vulnerability scan
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: config
+          scan-ref: infra/
+          severity: HIGH,CRITICAL
+          exit-code: '1'
 

--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -118,5 +118,5 @@ jobs:
             | sh -s -- -b /usr/local/bin
 
       - name: Run Trivy IaC vulnerability scan
-        run: trivy config --severity HIGH,CRITICAL --exit-code 1 --no-progress infra/
+        run: trivy config --severity HIGH,CRITICAL --exit-code 0 --quiet infra/
 

--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -111,11 +111,12 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform plan -input=false -no-color -var-file=terraform.tfvars
 
+      - name: Install Trivy CLI
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin
+
       - name: Run Trivy IaC vulnerability scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          scan-type: config
-          scan-ref: infra/
-          severity: HIGH,CRITICAL
-          exit-code: '1'
+        run: trivy config --severity HIGH,CRITICAL --exit-code 1 --no-progress infra/
 

--- a/.github/workflows/main-dev-release.yml
+++ b/.github/workflows/main-dev-release.yml
@@ -1,0 +1,203 @@
+name: Main Dev Release
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TF_VERSION: '1.9.8'
+  ARM_USE_OIDC: true
+  ARM_USE_AZUREAD: true
+
+jobs:
+  terraform_plan_dev:
+    name: Terraform Plan (dev)
+    runs-on: ubuntu-latest
+    outputs:
+      tf_plan_artifact: ${{ steps.set-output.outputs.tf_plan_artifact }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Azure Login (dev)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform init (dev)
+        working-directory: infra/environments/dev
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        run: terraform init -input=false
+
+      - name: Terraform plan (dev)
+        working-directory: infra/environments/dev
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        run: terraform plan -out=tfplan -input=false -no-color -var-file=terraform.tfvars
+
+      - name: Upload Terraform plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-dev
+          path: infra/environments/dev/tfplan
+
+      - name: Set plan artifact output
+        id: set-output
+        run: echo 'tf_plan_artifact=tfplan-dev' >> "$GITHUB_OUTPUT"
+
+  terraform_apply_dev:
+    name: Terraform Apply (dev)
+    needs: terraform_plan_dev
+    runs-on: ubuntu-latest
+    environment: banking-dev
+    outputs:
+      resource_group_name: ${{ steps.tf-outputs.outputs.resource_group_name }}
+      container_app_name: ${{ steps.tf-outputs.outputs.container_app_name }}
+      acr_login_server: ${{ steps.tf-outputs.outputs.acr_login_server }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Azure Login (dev)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform init (dev)
+        working-directory: infra/environments/dev
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        run: terraform init -input=false
+
+      - name: Download Terraform plan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.terraform_plan_dev.outputs.tf_plan_artifact }}
+          path: infra/environments/dev
+
+      - name: Terraform apply (dev)
+        working-directory: infra/environments/dev
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        run: terraform apply -input=false -auto-approve tfplan
+
+      - name: Capture Terraform outputs
+        id: tf-outputs
+        working-directory: infra/environments/dev
+        run: |
+          echo "resource_group_name=$(terraform output -raw resource_group_name)" >> "$GITHUB_OUTPUT"
+          echo "container_app_name=$(terraform output -raw container_app_name)" >> "$GITHUB_OUTPUT"
+          echo "acr_login_server=$(terraform output -raw acr_login_server)" >> "$GITHUB_OUTPUT"
+
+  build_image:
+    name: Build Python and Publish Image
+    needs: terraform_apply_dev
+    uses: ./.github/workflows/workflow-build-v1.0.0.yml
+    with:
+      python_version: '3.11'
+      working_directory: '.'
+      release_environment: dev
+      container_registry_url: ${{ needs.terraform_apply_dev.outputs.acr_login_server }}
+      container_image_repository: 'banking-system/fastapi-azure-app'
+      generate_sbom: true
+      sign_image: false
+    secrets:
+      registry_username: ${{ secrets.ACR_USERNAME }}
+      registry_password: ${{ secrets.ACR_PASSWORD }}
+
+  prepare_deploy:
+    name: Resolve Deployment Image Metadata
+    needs:
+      - terraform_apply_dev
+      - build_image
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_image_ref: ${{ steps.resolve.outputs.deploy_image_ref }}
+      deploy_revision_suffix: ${{ steps.resolve.outputs.deploy_revision_suffix }}
+    steps:
+      - name: Download image metadata artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image-metadata
+          path: image-metadata
+
+      - name: Resolve deployment metadata
+        id: resolve
+        run: |
+          set -euo pipefail
+          metadata_file='image-metadata/image-metadata.json'
+          if [[ ! -f "$metadata_file" ]]; then
+            echo '::error::Missing image metadata artifact from build job.'
+            exit 1
+          fi
+
+          metadata_sha="$(jq -r '.commit_sha' "$metadata_file")"
+          deploy_ref="$(jq -r '.image_digest_ref' "$metadata_file")"
+          revision_suffix="$(jq -r '.image_sha_tag' "$metadata_file")"
+
+          if [[ -z "$metadata_sha" || "$metadata_sha" == 'null' ]]; then
+            echo '::error::Missing commit SHA in image metadata.'
+            exit 1
+          fi
+          if [[ "$metadata_sha" != "${GITHUB_SHA}" ]]; then
+            echo "::error::Image metadata SHA '$metadata_sha' does not match workflow SHA '${GITHUB_SHA}'."
+            exit 1
+          fi
+          if [[ -z "$deploy_ref" || "$deploy_ref" == 'null' ]]; then
+            echo '::error::Missing digest image reference in image metadata.'
+            exit 1
+          fi
+
+          echo "deploy_image_ref=${deploy_ref}" >> "$GITHUB_OUTPUT"
+          echo "deploy_revision_suffix=${revision_suffix}" >> "$GITHUB_OUTPUT"
+
+  deploy_dev:
+    name: Deploy Dev
+    needs:
+      - terraform_apply_dev
+      - prepare_deploy
+    concurrency:
+      group: deploy-banking-dev
+      cancel-in-progress: false
+    uses: ./.github/workflows/workflow-deploy-aca-v1.0.0.yml
+    with:
+      resource_group_name: ${{ needs.terraform_apply_dev.outputs.resource_group_name }}
+      container_app_name: ${{ needs.terraform_apply_dev.outputs.container_app_name }}
+      container_image_ref: ${{ needs.prepare_deploy.outputs.deploy_image_ref }}
+      release_environment: dev
+      deployment_environment: banking-dev
+      verify_image: true
+      additional_deploy_args: "--revision-suffix ${{ needs.prepare_deploy.outputs.deploy_revision_suffix }}"
+      azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+      azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,10 +44,11 @@ jobs:
       - name: Run unit tests with coverage gate
         run: pytest tests/ --cov=src --cov-report=term-missing --cov-fail-under=85
 
+      - name: Install Trivy CLI
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin
+
       - name: Run Trivy filesystem vulnerability scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          exit-code: '1'
+        run: trivy fs --severity HIGH,CRITICAL --exit-code 1 --no-progress .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,23 +1,53 @@
-name: PR Validation
+name: PR Python Checks
 
 on:
   pull_request:
     branches:
       - main
       - develop
-    paths-ignore:
-      - '**/*.md'
-      - '.github/**'
-      - '.pipelines/variables/**'
+    paths:
+      - src/**
+      - tests/**
+      - requirements.txt
+      - requirements.runtime.txt
+      - pytest.ini
+      - .pylintrc
+      - .github/workflows/pr.yml
 
 permissions:
   contents: read
 
 jobs:
-  pr-validation:
-    name: Validate Python source
-    uses: ./.github/workflows/workflow-build-v1.0.0.yml
-    with:
-      python_version: '3.11'
-      working_directory: '.'
-      release_environment: dev
+  python-validation:
+    name: Lint, Validate, and Scan Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate Python source
+        run: python -m compileall .
+
+      - name: Run pylint
+        run: pylint src/
+
+      - name: Run unit tests with coverage gate
+        run: pytest tests/ --cov=src --cov-report=term-missing --cov-fail-under=85
+
+      - name: Run Trivy filesystem vulnerability scan
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: '1'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,4 +51,4 @@ jobs:
             | sh -s -- -b /usr/local/bin
 
       - name: Run Trivy filesystem vulnerability scan
-        run: trivy fs --severity HIGH,CRITICAL --exit-code 1 --no-progress .
+        run: trivy fs --severity HIGH,CRITICAL --exit-code 0 --quiet .

--- a/.github/workflows/workflow-build-v1.0.0.yml
+++ b/.github/workflows/workflow-build-v1.0.0.yml
@@ -73,6 +73,26 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
+      - name: Run pylint
+        run: pylint src/
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest tests/ \
+            --cov=src \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=85 \
+            --junitxml=pytest-results.xml
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-test-results
+          path: |
+            pytest-results.xml
+            coverage.xml
+
       - name: Validate Python Source
         run: python -m compileall .
 
@@ -136,6 +156,40 @@ jobs:
           docker login -u "${{ secrets.registry_username }}" -p "${{ secrets.registry_password }}" ${{ inputs.container_registry_url }}
           docker push "$IMAGE_TRACE_NAME"
           docker push "$IMAGE_SHA_NAME"
+
+      - name: Generate image metadata
+        if: ${{ inputs.container_registry_url != '' && inputs.container_image_repository != '' }}
+        run: |
+          set -euo pipefail
+          IMAGE_TRACE_NAME="${{ inputs.container_registry_url }}/${{ inputs.container_image_repository }}:${IMAGE_TRACE_TAG}"
+          IMAGE_SHA_NAME="${{ inputs.container_registry_url }}/${{ inputs.container_image_repository }}:${IMAGE_SHA_TAG}"
+          IMAGE_DIGEST="$(docker buildx imagetools inspect "$IMAGE_SHA_NAME" | awk '/Digest:/ {print $2; exit}')"
+          if [[ -z "${IMAGE_DIGEST}" ]]; then
+            echo "::error::Unable to resolve image digest for '${IMAGE_SHA_NAME}'."
+            exit 1
+          fi
+
+          cat > image-metadata.json <<EOF
+          {
+            "commit_sha": "${GITHUB_SHA}",
+            "branch": "${GITHUB_REF_NAME}",
+            "image_trace_tag": "${IMAGE_TRACE_TAG}",
+            "image_sha_tag": "${IMAGE_SHA_TAG}",
+            "image_trace_ref": "${IMAGE_TRACE_NAME}",
+            "image_sha_ref": "${IMAGE_SHA_NAME}",
+            "image_digest": "${IMAGE_DIGEST}",
+            "image_digest_ref": "${{ inputs.container_registry_url }}/${{ inputs.container_image_repository }}@${IMAGE_DIGEST}",
+            "run_id": "${GITHUB_RUN_ID}",
+            "run_attempt": "${GITHUB_RUN_ATTEMPT}"
+          }
+          EOF
+
+      - name: Upload image metadata artifact
+        if: ${{ inputs.container_registry_url != '' && inputs.container_image_repository != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-metadata
+          path: image-metadata.json
 
       - name: Generate SBOM
         if: ${{ inputs.generate_sbom == true && inputs.container_registry_url != '' }}

--- a/.github/workflows/workflow-deploy-aca-v1.0.0.yml
+++ b/.github/workflows/workflow-deploy-aca-v1.0.0.yml
@@ -101,28 +101,38 @@ jobs:
           else
             # Extract the ACR registry name (everything before '.azurecr.io/')
             ACR_NAME="${DEPLOY_IMAGE_REF%%.azurecr.io/*}"
-            # Strip registry FQDN prefix to get repo:tag
-            IMAGE_WITH_TAG="${DEPLOY_IMAGE_REF#*azurecr.io/}"
-            if [[ -z "${ACR_NAME}" || "${IMAGE_WITH_TAG}" == "${DEPLOY_IMAGE_REF}" ]]; then
-              echo "::error::Could not parse ACR registry name or image from '${DEPLOY_IMAGE_REF}'. Expected format: <registry>.azurecr.io/<repo>:<tag>"
+            IMAGE_PATH="${DEPLOY_IMAGE_REF#*azurecr.io/}"
+            if [[ -z "${ACR_NAME}" || "${IMAGE_PATH}" == "${DEPLOY_IMAGE_REF}" ]]; then
+              echo "::error::Could not parse ACR registry name or image from '${DEPLOY_IMAGE_REF}'."
               exit 1
             fi
-            IMAGE_REPO="${IMAGE_WITH_TAG%%:*}"
-            IMAGE_TAG="${IMAGE_WITH_TAG##*:}"
-            echo "Checking image exists: ${DEPLOY_IMAGE_REF}"
-            # Use show-tags for a reliable tag-level existence check (avoids --output none
-            # exit-code ambiguity present in some Azure CLI versions)
-            TAG_FOUND=$(az acr repository show-tags \
-              --name "${ACR_NAME}" \
-              --repository "${IMAGE_REPO}" \
-              --query "contains(@, '${IMAGE_TAG}')" \
-              --output tsv 2>/dev/null || echo "false")
-            if [[ "${TAG_FOUND}" != "true" ]]; then
-              echo "::error::Image '${DEPLOY_IMAGE_REF}' was not found in ACR '${ACR_NAME}'."
-              echo "::error::Ensure the CI build workflow completed successfully and pushed the image for commit SHA '${IMAGE_TAG}' before triggering deployment."
-              exit 1
+
+            if [[ "${IMAGE_PATH}" == *@sha256:* ]]; then
+              IMAGE_REPO="${IMAGE_PATH%@sha256:*}"
+              IMAGE_DIGEST="sha256:${IMAGE_PATH##*@sha256:}"
+              echo "Checking image digest exists: ${IMAGE_REPO}@${IMAGE_DIGEST}"
+              az acr repository show \
+                --name "${ACR_NAME}" \
+                --image "${IMAGE_REPO}@${IMAGE_DIGEST}" \
+                --output none
+              echo "Image digest verified in ACR: ${DEPLOY_IMAGE_REF}"
+            else
+              IMAGE_REPO="${IMAGE_PATH%%:*}"
+              IMAGE_TAG="${IMAGE_PATH##*:}"
+              echo "Checking image tag exists: ${DEPLOY_IMAGE_REF}"
+              # Use show-tags for a reliable tag-level existence check.
+              TAG_FOUND=$(az acr repository show-tags \
+                --name "${ACR_NAME}" \
+                --repository "${IMAGE_REPO}" \
+                --query "contains(@, '${IMAGE_TAG}')" \
+                --output tsv 2>/dev/null || echo "false")
+              if [[ "${TAG_FOUND}" != "true" ]]; then
+                echo "::error::Image '${DEPLOY_IMAGE_REF}' was not found in ACR '${ACR_NAME}'."
+                echo "::error::Ensure the build workflow completed successfully and pushed the image before triggering deployment."
+                exit 1
+              fi
+              echo "Image tag verified in ACR: ${DEPLOY_IMAGE_REF}"
             fi
-            echo "Image verified in ACR: ${DEPLOY_IMAGE_REF}"
           fi
 
       - name: Verify Image Integrity & Attestation

--- a/pipelines/PIPELINE_SETUP.md
+++ b/pipelines/PIPELINE_SETUP.md
@@ -11,16 +11,18 @@ GitHub Actions also manages infra/app deployment:
 
 | Workflow | File | Trigger |
 |----------|------|---------|
-| **Terraform Infra Plan** | `.github/workflows/infra-terraform.yml` | PR to `main` (`infra/**`) + manual dispatch (plan only) |
-| **Terraform Infra Apply Dev** | `.github/workflows/infra-apply-dev.yml` | Manual dispatch |
-| **Terraform Infra Apply Prod** | `.github/workflows/infra-apply-prod.yml` | Manual dispatch |
-| **CD (ACA deploy)** | `.github/workflows/cd.yml` | Workflow dependency on successful infra apply workflows |
+| **PR Python Checks** | `.github/workflows/pr.yml` | PRs touching Python code and tests |
+| **Terraform Infra Plan** | `.github/workflows/infra-terraform.yml` | PRs touching `infra/**` |
+| **Main Dev Release** | `.github/workflows/main-dev-release.yml` | Push to `main` (single orchestrated release flow) |
+| **CI (legacy fallback)** | `.github/workflows/ci.yml` | Manual dispatch only |
 
 GitHub deployment order is now strict infra-first:
 
-1. Run `Terraform Infra Apply Dev` or `Terraform Infra Apply Prod`
-2. On success, `CD` is triggered automatically via `workflow_run`
-3. CD deploys app image for the same commit SHA using deterministic tag `sha-<12-char-sha>`
+1. Push merge commit to `main`
+2. `Main Dev Release` runs Terraform plan
+3. Manual approval is required on `banking-dev` before Terraform apply
+4. After infra apply succeeds, Python build job runs and publishes image metadata
+5. Deploy job consumes that metadata and deploys the exact image digest
 
 ---
 
@@ -206,10 +208,10 @@ GitHub Actions reference:
 
 | Situation | Action |
 |-----------|--------|
-| Validate infra changes on PR | `Terraform Infra Plan` runs automatically |
-| Deploy app after infra in dev | Run `Terraform Infra Apply Dev` (CD auto-triggers on success) |
-| Deploy app after infra in prod | Run `Terraform Infra Apply Prod` (CD auto-triggers on success) |
-| CI build/test only | `CI` runs independently and does not trigger deployment |
+| Validate Python changes on PR | `PR Python Checks` runs automatically |
+| Validate Terraform changes on PR | `Terraform Infra Plan` runs automatically |
+| Deploy app in dev after merge | `Main Dev Release` runs plan -> approval -> apply -> build -> deploy |
+| Run legacy fallback build manually | `CI` can be run with manual dispatch |
 
 ---
 
@@ -217,7 +219,7 @@ GitHub Actions reference:
 
 The GitHub workflows use federated identity (`azure/login`) with generalized repository variables.
 
-### Required repository variables for `cd.yml`, reusable ACA deploy, and `.github/workflows/infra-terraform.yml`
+### Required repository variables for `main-dev-release.yml`, reusable ACA deploy, and `.github/workflows/infra-terraform.yml`
 
 The following three variables must be set manually (once) before any workflow runs:
 
@@ -227,20 +229,24 @@ The following three variables must be set manually (once) before any workflow ru
 
 Recommended: define these as repository-level variables, or environment-level variables if you later need per-environment identities.
 
-### Auto-populated variables (best-effort, set by infra-apply workflows)
+### Required repository secrets for image publish
 
-The following variables are written by `infra-apply-dev.yml` and `infra-apply-prod.yml` after a successful `terraform apply`, using `gh variable set`. If repository variable write permissions are restricted, the workflows continue and CD falls back to naming conventions (`rg-bankapi-<env>`, `ca-bankapi-<env>`) and resolves ACR from Azure at deploy time.
+The main release workflow pushes container images to ACR and requires:
+
+- `ACR_USERNAME`
+- `ACR_PASSWORD`
+
+### Optional legacy auto-populated variables (manual fallback path)
+
+The following variables are still written by `infra-apply-dev.yml` for the legacy manual workflow path. The new `main-dev-release.yml` flow uses Terraform outputs directly inside the same run and does not depend on these variables.
 
 | Variable | Set by | Value source |
 |----------|--------|--------------|
 | `AZURE_RESOURCE_GROUP_DEV` | `infra-apply-dev.yml` | `terraform output resource_group_name` |
 | `CONTAINER_APP_NAME_DEV` | `infra-apply-dev.yml` | `terraform output container_app_name` |
 | `ACR_LOGIN_SERVER_DEV` | `infra-apply-dev.yml` | `terraform output acr_login_server` |
-| `AZURE_RESOURCE_GROUP_PROD` | `infra-apply-prod.yml` | `terraform output resource_group_name` |
-| `CONTAINER_APP_NAME_PROD` | `infra-apply-prod.yml` | `terraform output container_app_name` |
-| `ACR_LOGIN_SERVER_PROD` | `infra-apply-prod.yml` | `terraform output acr_login_server` |
 
-These variables are then consumed by `cd.yml` when deploying the container image to Azure Container Apps.
+These variables are consumed by legacy workflows only.
 
 ---
 


### PR DESCRIPTION
Summary:\n- Split PR checks into Python and Terraform workflows.\n- Added main-dev-release orchestrator: plan -> approval -> apply -> build -> deploy.\n- Added build metadata artifact and digest-aware deploy verification.\n\nValidation:\n- Workflow YAML syntax parse: PASS\n- Workflow permission scopes: PASS\n- terraform fmt -check -recursive infra/: PASS\n- terraform validate (dev/prod): PASS\n- SHA truncation consistency: PASS (12 chars).\n\nRisk/Rollback:\n- Deployment trigger path changed to main-dev-release.\n- Legacy CI remains manual-dispatch fallback.