### PR TITLE
fix: align ACR deployer principal wiring and API test mappings

### DIFF
--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -10,7 +10,7 @@ project_name = "fastapi-azure-app"
 
 # Optional override for deployment principal object ID used by bootstrap/deployer RBAC.
 # Set to null to use the currently authenticated principal.
-deployment_principal_object_id = null
+deployment_principal_object_id = "f30f7785-c05b-4c94-819f-63f009dd7b6e"
 
 # RBAC bootstrap — disabled because the CI/CD service principal cannot
 # self-assign roleAssignments/write (circular bootstrap deadlock).

--- a/src/api/accounts.py
+++ b/src/api/accounts.py
@@ -73,13 +73,21 @@ def _raise_http(exc: Exception) -> NoReturn:
         HTTPException: Always raised with the appropriate HTTP status code.
     """
     if isinstance(exc, AccountNotFoundException):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     if isinstance(exc, AccountTypeNotFoundException):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     if isinstance(exc, AccountAlreadyClosedException):
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
+        ) from exc
     if isinstance(exc, InsufficientPermissionsException):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     logger.exception("Unexpected exception in account API handler", exc_info=exc)
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/api/profile.py
+++ b/src/api/profile.py
@@ -57,7 +57,9 @@ def _raise_http(exc: Exception) -> NoReturn:
         HTTPException: Always raised with the appropriate HTTP status code.
     """
     if isinstance(exc, UserProfileNotFoundException):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     logger.exception("Unexpected exception in profile API handler", exc_info=exc)
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tests/test_api/test_accounts.py
+++ b/tests/test_api/test_accounts.py
@@ -10,16 +10,50 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from src.exceptions.domain_exceptions import (
     AccountAlreadyClosedException,
     AccountNotFoundException,
+    AccountTypeNotFoundException,
     InsufficientPermissionsException,
 )
 from src.models.account import AccountStatus
 
 from tests.conftest import ACCOUNT_NUMBER, CLOSED_DOC, OWNER_ID, make_account_doc
+
+
+# ── _raise_http mapping regression coverage ───────────────────────────────────
+
+
+class TestRaiseHttpMappings:
+    """Direct unit tests for src.api.accounts._raise_http."""
+
+    @pytest.mark.parametrize(
+        ("exc", "expected_status"),
+        [
+            (AccountNotFoundException(ACCOUNT_NUMBER), 404),
+            (AccountTypeNotFoundException("CURRENT"), 404),
+            (AccountAlreadyClosedException(ACCOUNT_NUMBER), 409),
+            (InsufficientPermissionsException("forbidden"), 403),
+        ],
+    )
+    def test_raise_http_domain_exception_maps_to_expected_status(
+        self, exc: Exception, expected_status: int
+    ) -> None:
+        from src.api.accounts import _raise_http
+
+        with pytest.raises(HTTPException) as raised:
+            _raise_http(exc)
+        assert raised.value.status_code == expected_status
+
+    def test_raise_http_unexpected_exception_maps_to_500(self) -> None:
+        from src.api.accounts import _raise_http
+
+        with pytest.raises(HTTPException) as raised:
+            _raise_http(RuntimeError("unexpected"))
+        assert raised.value.status_code == 500
 
 
 # ── POST /accounts ─────────────────────────────────────────────────────────────

--- a/tests/test_api/test_profile.py
+++ b/tests/test_api/test_profile.py
@@ -45,6 +45,28 @@ VALID_PATCH_BODY: dict = {
 
 CUSTOMER_USER: dict = {"sub": OWNER_ID, "role": "customer"}
 
+
+# ── _raise_http mapping regression coverage ───────────────────────────────────
+
+
+class TestRaiseHttpMappings:
+    """Direct unit tests for src.api.profile._raise_http."""
+
+    def test_raise_http_user_profile_not_found_maps_to_404(self) -> None:
+        from src.api.profile import _raise_http
+
+        with pytest.raises(HTTPException) as raised:
+            _raise_http(UserProfileNotFoundException(OWNER_ID))
+        assert raised.value.status_code == 404
+
+    def test_raise_http_unexpected_exception_maps_to_500(self) -> None:
+        from src.api.profile import _raise_http
+
+        with pytest.raises(HTTPException) as raised:
+            _raise_http(RuntimeError("unexpected"))
+        assert raised.value.status_code == 500
+
+
 # ── Test app factory ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Summary: pin dev deployment principal object ID for ACR role assignment path; include API exception mapping updates and regression tests. Why: ensure Terraform targets intended identity and preserve tested exception behavior. Validation: branch committed and pushed; prior local pytest coverage run reported passing. Note: pytest.log intentionally excluded.