### PR TITLE
fix: harden Terraform RBAC bootstrap and AppConfig plan readiness

### DIFF
--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -103,6 +103,71 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform validate -no-color
 
+      - name: Verify data-plane RBAC readiness (dev)
+        run: |
+          set -euo pipefail
+
+          current_oid="$(az ad sp show --id "${{ vars.AZURE_CLIENT_ID }}" --query id -o tsv)"
+          sub_id="$(az account show --query id -o tsv)"
+          rg_name="rg-bankapi-dev"
+
+          kv_name="$(az keyvault list -g "${rg_name}" --query "[?starts_with(name, 'kv-bankapi-dev-')].name | [0]" -o tsv || true)"
+          appconfig_name="$(az appconfig list -g "${rg_name}" --query "[?starts_with(name, 'appcs-bankapi-dev')].name | [0]" -o tsv || true)"
+
+          check_role() {
+            local role_name="$1"
+            local scope="$2"
+            local count
+            count="$(az role assignment list --assignee-object-id "${current_oid}" --scope "${scope}" --query "[?roleDefinitionName=='${role_name}'] | length(@)" -o tsv)"
+            [[ "${count:-0}" != "0" ]]
+          }
+
+          if [[ -n "${appconfig_name}" ]]; then
+            appconfig_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.AppConfiguration/configurationStores/${appconfig_name}"
+            if ! check_role "App Configuration Data Owner" "${appconfig_scope}"; then
+              echo "ERROR: Missing 'App Configuration Data Owner' for ${current_oid} on ${appconfig_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az appconfig kv list --name "${appconfig_name}" --auth-mode login --top 1 1>/dev/null 2>/dev/null; then
+                echo "App Configuration data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: App Configuration data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for App Configuration RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev App Configuration store found; skipping App Configuration data-plane probe."
+          fi
+
+          if [[ -n "${kv_name}" ]]; then
+            kv_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.KeyVault/vaults/${kv_name}"
+            if ! check_role "Key Vault Administrator" "${kv_scope}"; then
+              echo "ERROR: Missing 'Key Vault Administrator' for ${current_oid} on ${kv_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az keyvault secret list --vault-name "${kv_name}" --maxresults 1 1>/dev/null 2>/dev/null; then
+                echo "Key Vault data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: Key Vault data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for Key Vault RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev Key Vault found; skipping Key Vault data-plane probe."
+          fi
+
       - name: Terraform plan (dev)
         working-directory: infra/environments/dev
         env:

--- a/.github/workflows/main-dev-release.yml
+++ b/.github/workflows/main-dev-release.yml
@@ -46,6 +46,71 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform init -input=false
 
+      - name: Verify data-plane RBAC readiness (dev)
+        run: |
+          set -euo pipefail
+
+          current_oid="$(az ad sp show --id "${{ vars.AZURE_CLIENT_ID }}" --query id -o tsv)"
+          sub_id="$(az account show --query id -o tsv)"
+          rg_name="rg-bankapi-dev"
+
+          kv_name="$(az keyvault list -g "${rg_name}" --query "[?starts_with(name, 'kv-bankapi-dev-')].name | [0]" -o tsv || true)"
+          appconfig_name="$(az appconfig list -g "${rg_name}" --query "[?starts_with(name, 'appcs-bankapi-dev')].name | [0]" -o tsv || true)"
+
+          check_role() {
+            local role_name="$1"
+            local scope="$2"
+            local count
+            count="$(az role assignment list --assignee-object-id "${current_oid}" --scope "${scope}" --query "[?roleDefinitionName=='${role_name}'] | length(@)" -o tsv)"
+            [[ "${count:-0}" != "0" ]]
+          }
+
+          if [[ -n "${appconfig_name}" ]]; then
+            appconfig_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.AppConfiguration/configurationStores/${appconfig_name}"
+            if ! check_role "App Configuration Data Owner" "${appconfig_scope}"; then
+              echo "ERROR: Missing 'App Configuration Data Owner' for ${current_oid} on ${appconfig_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az appconfig kv list --name "${appconfig_name}" --auth-mode login --top 1 1>/dev/null 2>/dev/null; then
+                echo "App Configuration data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: App Configuration data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for App Configuration RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev App Configuration store found; skipping App Configuration data-plane probe."
+          fi
+
+          if [[ -n "${kv_name}" ]]; then
+            kv_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.KeyVault/vaults/${kv_name}"
+            if ! check_role "Key Vault Administrator" "${kv_scope}"; then
+              echo "ERROR: Missing 'Key Vault Administrator' for ${current_oid} on ${kv_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az keyvault secret list --vault-name "${kv_name}" --maxresults 1 1>/dev/null 2>/dev/null; then
+                echo "Key Vault data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: Key Vault data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for Key Vault RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev Key Vault found; skipping Key Vault data-plane probe."
+          fi
+
       - name: Terraform plan (dev)
         working-directory: infra/environments/dev
         env:

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -10,7 +10,7 @@ project_name = "fastapi-azure-app"
 
 # Optional override for deployment principal object ID used by bootstrap/deployer RBAC.
 # Set to null to use the currently authenticated principal.
-deployment_principal_object_id = "cd7ca1e6-67f4-4120-b3a2-615de398cc6a"
+deployment_principal_object_id = null
 
 # RBAC bootstrap sequencing (operator runbook):
 # 1. Run scripts/bootstrap_pipeline_rbac.sh as a privileged operator to grant

--- a/pipelines/tf-infra-apply.yml
+++ b/pipelines/tf-infra-apply.yml
@@ -168,6 +168,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           - task: AzureCLI@2
@@ -185,6 +186,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           - task: AzureCLI@2
@@ -202,6 +204,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Agent.TempDirectory)/plan-preview.txt"
 
@@ -324,6 +327,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       terraform init -input=false
 
                 # Re-plan fresh (guards against state drift since PlanPreview ran)
@@ -342,6 +346,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       echo "Re-running plan to guard against state drift ..."
                       terraform plan -out=tfplan -input=false -no-color -var-file=terraform.tfvars
 
@@ -360,6 +365,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       terraform apply -auto-approve -input=false tfplan
 
                 - task: AzureCLI@2

--- a/pipelines/tf-infra-plan.yml
+++ b/pipelines/tf-infra-plan.yml
@@ -174,6 +174,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           # ── Validate ──────────────────────────────────────────────────────
@@ -192,6 +193,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           # ── Plan ──────────────────────────────────────────────────────────
@@ -210,6 +212,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Build.ArtifactStagingDirectory)/plan-dev.txt"
 
@@ -377,6 +380,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           - task: AzureCLI@2
@@ -394,6 +398,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           - task: AzureCLI@2
@@ -411,6 +416,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Build.ArtifactStagingDirectory)/plan-prod.txt"
 

--- a/scripts/bootstrap_pipeline_rbac.sh
+++ b/scripts/bootstrap_pipeline_rbac.sh
@@ -3,10 +3,98 @@ set -euo pipefail
 
 # Manual prerequisite bootstrap for Terraform pipeline identity.
 # Run this with a privileged operator identity (Owner or User Access Administrator)
-# before enabling rbac_bootstrap in terraform.tfvars.
+# before running infra apply workflows.
 
-readonly PIPELINE_CLIENT_ID="05baf6a1-cae6-442a-94d6-f0d1f64b61f4"
-readonly PIPELINE_OBJECT_ID="cd7ca1e6-67f4-4120-b3a2-615de398cc6a"
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id <service-principal-client-id> \
+    [--object-id <service-principal-object-id>] \
+    [--subscription-id <subscription-id>] \
+    [--resource-group <resource-group-name>] \
+    [--acr-name <acr-name>] \
+    [--keyvault-name <keyvault-name>] \
+    [--appconfig-name <appconfig-name>]
+
+Description:
+  Idempotently assigns required roles to the Terraform/GitHub federated deployer identity.
+  Always grants subscription-scope Contributor + ABAC-constrained User Access Administrator.
+  Optionally grants resource-scope roles for existing resources:
+    - ACR: AcrPush
+    - Key Vault: Key Vault Administrator
+    - App Configuration: App Configuration Data Owner
+
+Examples:
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id 05baf6a1-cae6-442a-94d6-f0d1f64b61f4 \
+    --object-id cd7ca1e6-67f4-4120-b3a2-615de398cc6a
+
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id 05baf6a1-cae6-442a-94d6-f0d1f64b61f4 \
+    --object-id cd7ca1e6-67f4-4120-b3a2-615de398cc6a \
+    --resource-group rg-bankapi-dev \
+    --acr-name acrbankapidevc8775a \
+    --keyvault-name kv-bankapi-dev-c8775a \
+    --appconfig-name appcs-bankapi-dev
+EOF
+}
+
+PIPELINE_CLIENT_ID=""
+PIPELINE_OBJECT_ID=""
+SUBSCRIPTION_ID=""
+RESOURCE_GROUP=""
+ACR_NAME=""
+KEYVAULT_NAME=""
+APPCONFIG_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --client-id)
+      PIPELINE_CLIENT_ID="$2"
+      shift 2
+      ;;
+    --object-id)
+      PIPELINE_OBJECT_ID="$2"
+      shift 2
+      ;;
+    --subscription-id)
+      SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    --resource-group)
+      RESOURCE_GROUP="$2"
+      shift 2
+      ;;
+    --acr-name)
+      ACR_NAME="$2"
+      shift 2
+      ;;
+    --keyvault-name)
+      KEYVAULT_NAME="$2"
+      shift 2
+      ;;
+    --appconfig-name)
+      APPCONFIG_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${PIPELINE_CLIENT_ID}" ]]; then
+  echo "--client-id is required." >&2
+  usage
+  exit 1
+fi
 
 readonly CONTRIBUTOR_ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"
 readonly UAA_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
@@ -22,7 +110,9 @@ if ! command -v az >/dev/null 2>&1; then
   exit 1
 fi
 
-SUBSCRIPTION_ID="${1:-$(az account show --query id -o tsv)}"
+if [[ -z "${SUBSCRIPTION_ID}" ]]; then
+  SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+fi
 SUBSCRIPTION_SCOPE="/subscriptions/${SUBSCRIPTION_ID}"
 
 readonly UAA_ABAC_CONDITION="(
@@ -46,6 +136,15 @@ readonly UAA_ABAC_CONDITION="(
 
 echo "Using subscription: ${SUBSCRIPTION_ID}"
 echo "Target principal client id: ${PIPELINE_CLIENT_ID}"
+resolved_oid="$(az ad sp show --id "${PIPELINE_CLIENT_ID}" --query id -o tsv)"
+if [[ -z "${PIPELINE_OBJECT_ID}" ]]; then
+  PIPELINE_OBJECT_ID="${resolved_oid}"
+  echo "Resolved principal object id from client id: ${PIPELINE_OBJECT_ID}"
+elif [[ "${resolved_oid}" != "${PIPELINE_OBJECT_ID}" ]]; then
+  echo "WARNING: --client-id resolves to object id ${resolved_oid}, but --object-id was ${PIPELINE_OBJECT_ID}." >&2
+  echo "WARNING: Continuing with resolved service principal object id: ${resolved_oid}" >&2
+  PIPELINE_OBJECT_ID="${resolved_oid}"
+fi
 echo "Target principal object id: ${PIPELINE_OBJECT_ID}"
 echo
 
@@ -98,6 +197,62 @@ else
     --only-show-errors \
     1>/dev/null
   echo "User Access Administrator assignment created with ABAC condition."
+fi
+
+assignment_exists_for_scope() {
+  local role_name="$1"
+  local scope="$2"
+  local query="[?roleDefinitionName=='${role_name}' && scope=='${scope}'] | length(@)"
+  local count
+  count="$(az role assignment list \
+    --assignee-object-id "${PIPELINE_OBJECT_ID}" \
+    --scope "${scope}" \
+    --query "${query}" \
+    -o tsv)"
+  [[ "${count:-0}" != "0" ]]
+}
+
+ensure_role_assignment() {
+  local role_name="$1"
+  local scope="$2"
+
+  if assignment_exists_for_scope "${role_name}" "${scope}"; then
+    echo "${role_name} already assigned at ${scope}; skipping create."
+    return
+  fi
+
+  echo "Assigning ${role_name} at ${scope}..."
+  az role assignment create \
+    --assignee-object-id "${PIPELINE_OBJECT_ID}" \
+    --assignee-principal-type ServicePrincipal \
+    --role "${role_name}" \
+    --scope "${scope}" \
+    --only-show-errors \
+    1>/dev/null
+  echo "${role_name} assignment created at ${scope}."
+}
+
+# Optional resource-scope grants to recover from stale/missing deployer RBAC.
+if [[ -n "${RESOURCE_GROUP}" ]]; then
+  resource_group_scope="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
+
+  if [[ -n "${ACR_NAME}" ]]; then
+    acr_scope="${resource_group_scope}/providers/Microsoft.ContainerRegistry/registries/${ACR_NAME}"
+    ensure_role_assignment "AcrPush" "${acr_scope}"
+  fi
+
+  if [[ -n "${KEYVAULT_NAME}" ]]; then
+    kv_scope="${resource_group_scope}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}"
+    ensure_role_assignment "Key Vault Administrator" "${kv_scope}"
+  fi
+
+  if [[ -n "${APPCONFIG_NAME}" ]]; then
+    appconfig_scope="${resource_group_scope}/providers/Microsoft.AppConfiguration/configurationStores/${APPCONFIG_NAME}"
+    ensure_role_assignment "App Configuration Data Owner" "${appconfig_scope}"
+  fi
+elif [[ -n "${ACR_NAME}" || -n "${KEYVAULT_NAME}" || -n "${APPCONFIG_NAME}" ]]; then
+  echo "ERROR: --resource-group is required when using --acr-name, --keyvault-name, or --appconfig-name." >&2
+  exit 1
 fi
 
 echo


### PR DESCRIPTION
## Summary
This PR fixes recurring Terraform plan/apply authorization failures across GitHub Actions and Azure DevOps by hardening deployer identity handling, data-plane auth configuration, and pre-plan readiness checks.

## What Changed
- Updated bootstrap helper to resolve service principal object id from client id and tolerate mismatched app-registration object id input.
- Switched dev Terraform deployer principal selection to dynamic resolution:
  - `deployment_principal_object_id = null`
- Added pre-plan data-plane readiness checks in GitHub workflows for:
  - App Configuration Data Owner + probe
  - Key Vault Administrator + probe
- Added `ARM_USE_AZUREAD=true` in Azure DevOps Terraform plan/apply scripts wherever OIDC auth is exported.

## Files
- `.github/workflows/infra-terraform.yml`
- `.github/workflows/main-dev-release.yml`
- `infra/environments/dev/terraform.tfvars`
- `pipelines/tf-infra-plan.yml`
- `pipelines/tf-infra-apply.yml`
- `scripts/bootstrap_pipeline_rbac.sh`

## Validation Performed
- RBAC bootstrap command executed successfully for active failing identity and verified scope assignments.
- YAML syntax validation passed for modified workflow/pipeline files.
- Workflow permission-scope gate passed.

## Risk / Rollback
- Low risk; changes are isolated to RBAC orchestration and pipeline env/auth settings.
- Rollback: revert this PR commit to restore previous pipeline behavior.
