### PR TITLE
fix: move deployer RBAC ownership to bootstrap script

### DIFF
--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -103,6 +103,71 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform validate -no-color
 
+      - name: Verify data-plane RBAC readiness (dev)
+        run: |
+          set -euo pipefail
+
+          current_oid="$(az ad sp show --id "${{ vars.AZURE_CLIENT_ID }}" --query id -o tsv)"
+          sub_id="$(az account show --query id -o tsv)"
+          rg_name="rg-bankapi-dev"
+
+          kv_name="$(az keyvault list -g "${rg_name}" --query "[?starts_with(name, 'kv-bankapi-dev-')].name | [0]" -o tsv || true)"
+          appconfig_name="$(az appconfig list -g "${rg_name}" --query "[?starts_with(name, 'appcs-bankapi-dev')].name | [0]" -o tsv || true)"
+
+          check_role() {
+            local role_name="$1"
+            local scope="$2"
+            local count
+            count="$(az role assignment list --assignee-object-id "${current_oid}" --scope "${scope}" --query "[?roleDefinitionName=='${role_name}'] | length(@)" -o tsv)"
+            [[ "${count:-0}" != "0" ]]
+          }
+
+          if [[ -n "${appconfig_name}" ]]; then
+            appconfig_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.AppConfiguration/configurationStores/${appconfig_name}"
+            if ! check_role "App Configuration Data Owner" "${appconfig_scope}"; then
+              echo "ERROR: Missing 'App Configuration Data Owner' for ${current_oid} on ${appconfig_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az appconfig kv list --name "${appconfig_name}" --auth-mode login --top 1 1>/dev/null 2>/dev/null; then
+                echo "App Configuration data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: App Configuration data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for App Configuration RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev App Configuration store found; skipping App Configuration data-plane probe."
+          fi
+
+          if [[ -n "${kv_name}" ]]; then
+            kv_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.KeyVault/vaults/${kv_name}"
+            if ! check_role "Key Vault Administrator" "${kv_scope}"; then
+              echo "ERROR: Missing 'Key Vault Administrator' for ${current_oid} on ${kv_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az keyvault secret list --vault-name "${kv_name}" --maxresults 1 1>/dev/null 2>/dev/null; then
+                echo "Key Vault data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: Key Vault data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for Key Vault RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev Key Vault found; skipping Key Vault data-plane probe."
+          fi
+
       - name: Terraform plan (dev)
         working-directory: infra/environments/dev
         env:

--- a/.github/workflows/main-dev-release.yml
+++ b/.github/workflows/main-dev-release.yml
@@ -46,6 +46,71 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: terraform init -input=false
 
+      - name: Verify data-plane RBAC readiness (dev)
+        run: |
+          set -euo pipefail
+
+          current_oid="$(az ad sp show --id "${{ vars.AZURE_CLIENT_ID }}" --query id -o tsv)"
+          sub_id="$(az account show --query id -o tsv)"
+          rg_name="rg-bankapi-dev"
+
+          kv_name="$(az keyvault list -g "${rg_name}" --query "[?starts_with(name, 'kv-bankapi-dev-')].name | [0]" -o tsv || true)"
+          appconfig_name="$(az appconfig list -g "${rg_name}" --query "[?starts_with(name, 'appcs-bankapi-dev')].name | [0]" -o tsv || true)"
+
+          check_role() {
+            local role_name="$1"
+            local scope="$2"
+            local count
+            count="$(az role assignment list --assignee-object-id "${current_oid}" --scope "${scope}" --query "[?roleDefinitionName=='${role_name}'] | length(@)" -o tsv)"
+            [[ "${count:-0}" != "0" ]]
+          }
+
+          if [[ -n "${appconfig_name}" ]]; then
+            appconfig_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.AppConfiguration/configurationStores/${appconfig_name}"
+            if ! check_role "App Configuration Data Owner" "${appconfig_scope}"; then
+              echo "ERROR: Missing 'App Configuration Data Owner' for ${current_oid} on ${appconfig_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az appconfig kv list --name "${appconfig_name}" --auth-mode login --top 1 1>/dev/null 2>/dev/null; then
+                echo "App Configuration data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: App Configuration data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for App Configuration RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev App Configuration store found; skipping App Configuration data-plane probe."
+          fi
+
+          if [[ -n "${kv_name}" ]]; then
+            kv_scope="/subscriptions/${sub_id}/resourceGroups/${rg_name}/providers/Microsoft.KeyVault/vaults/${kv_name}"
+            if ! check_role "Key Vault Administrator" "${kv_scope}"; then
+              echo "ERROR: Missing 'Key Vault Administrator' for ${current_oid} on ${kv_scope}." >&2
+              exit 1
+            fi
+
+            for attempt in {1..12}; do
+              if az keyvault secret list --vault-name "${kv_name}" --maxresults 1 1>/dev/null 2>/dev/null; then
+                echo "Key Vault data-plane access confirmed."
+                break
+              fi
+              if [[ "${attempt}" == "12" ]]; then
+                echo "ERROR: Key Vault data-plane access not ready after waiting for RBAC propagation." >&2
+                exit 1
+              fi
+              echo "Waiting for Key Vault RBAC propagation (attempt ${attempt}/12)..."
+              sleep 10
+            done
+          else
+            echo "No existing dev Key Vault found; skipping Key Vault data-plane probe."
+          fi
+
       - name: Terraform plan (dev)
         working-directory: infra/environments/dev
         env:

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -6,13 +6,8 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  app_name                = "bankapi"
-  unique_suffix           = substr(data.azurerm_client_config.current.subscription_id, 27, 6)
-  project_repository_path = "project/${var.project_name}"
-  deployment_principal_object_id = coalesce(
-    var.deployment_principal_object_id,
-    data.azurerm_client_config.current.object_id,
-  )
+  app_name      = "bankapi"
+  unique_suffix = substr(data.azurerm_client_config.current.subscription_id, 27, 6)
 
   # cosmos_location falls back to the primary region when not explicitly overridden.
   # Override in tfvars to work around regional capacity constraints (e.g. East US AZ quota).
@@ -31,20 +26,6 @@ resource "azurerm_resource_group" "main" {
   name     = "rg-${local.app_name}-${var.env}"
   location = var.location
   tags     = local.common_tags
-}
-
-# ---------------------------------------------------------------------------
-# RBAC bootstrap for deployment principal (management-plane role assignment rights)
-# ---------------------------------------------------------------------------
-module "rbac_bootstrap" {
-  source = "../../modules/rbac_bootstrap"
-
-  enabled                          = var.rbac_bootstrap_enabled
-  resource_group_id                = azurerm_resource_group.main.id
-  deployment_principal_object_id   = local.deployment_principal_object_id
-  role_definition_names            = var.rbac_bootstrap_role_definition_names
-  uaa_condition                    = var.rbac_bootstrap_uaa_condition
-  skip_service_principal_aad_check = var.rbac_bootstrap_skip_sp_aad_check
 }
 
 # ---------------------------------------------------------------------------
@@ -83,15 +64,10 @@ module "monitoring" {
 }
 
 # ---------------------------------------------------------------------------
-# Cosmos DB — account, database, container + deployer RBAC
-# Depends on rbac_bootstrap so the deployment principal holds the Contributor
-# role (needed for Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write)
-# before the Cosmos DB SQL role assignment is attempted.
+# Cosmos DB — account, database, container + app UAMI RBAC
 # ---------------------------------------------------------------------------
 module "cosmosdb" {
   source = "../../modules/cosmosdb"
-
-  depends_on = [module.rbac_bootstrap]
 
   resource_group_name      = azurerm_resource_group.main.name
   location                 = local.cosmos_location
@@ -100,7 +76,6 @@ module "cosmosdb" {
   unique_suffix            = local.unique_suffix
   enable_serverless        = var.enable_serverless
   db_name                  = var.cosmos_db_name
-  deployer_object_id       = local.deployment_principal_object_id
   app_uami_principal_id    = module.keyvault.uami_principal_id
   assign_app_cosmosdb_role = true
   tags                     = local.common_tags
@@ -113,15 +88,12 @@ module "cosmosdb" {
 module "keyvault" {
   source = "../../modules/keyvault"
 
-  depends_on = [module.rbac_bootstrap]
-
   resource_group_name            = azurerm_resource_group.main.name
   location                       = azurerm_resource_group.main.location
   app_name                       = local.app_name
   env                            = var.env
   unique_suffix                  = local.unique_suffix
   tenant_id                      = data.azurerm_client_config.current.tenant_id
-  deployer_object_id             = local.deployment_principal_object_id
   kv_sku                         = var.kv_sku
   kv_soft_delete_retention_days  = var.kv_soft_delete_retention_days
   purge_protection_enabled       = var.purge_protection_enabled
@@ -137,13 +109,10 @@ module "keyvault" {
 module "appconfig" {
   source = "../../modules/appconfig"
 
-  depends_on = [module.rbac_bootstrap]
-
   resource_group_name        = azurerm_resource_group.main.name
   location                   = azurerm_resource_group.main.location
   app_name                   = local.app_name
   env                        = var.env
-  deployer_object_id         = local.deployment_principal_object_id
   app_identity_principal_id  = module.keyvault.uami_principal_id
   app_config_sku             = var.app_config_sku
   soft_delete_retention_days = var.app_config_soft_delete_days
@@ -156,16 +125,14 @@ module "appconfig" {
 module "acr" {
   source = "../../modules/acr"
 
-  resource_group_name     = azurerm_resource_group.main.name
-  location                = azurerm_resource_group.main.location
-  app_name                = local.app_name
-  env                     = var.env
-  unique_suffix           = local.unique_suffix
-  acr_sku                 = var.acr_sku
-  uami_principal_id       = module.keyvault.uami_principal_id
-  deployer_object_id      = local.deployment_principal_object_id
-  project_repository_path = local.project_repository_path
-  tags                    = local.common_tags
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  app_name            = local.app_name
+  env                 = var.env
+  unique_suffix       = local.unique_suffix
+  acr_sku             = var.acr_sku
+  uami_principal_id   = module.keyvault.uami_principal_id
+  tags                = local.common_tags
 
   # UAMI must exist before we can assign the AcrPull role
   depends_on = [module.keyvault]
@@ -225,4 +192,49 @@ module "container_app" {
   smtp_timeout_seconds = var.smtp_timeout_seconds
 
   tags = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# State migration: deployer RBAC is now script-managed.
+# Remove legacy deployer assignments from Terraform state without deleting
+# live Azure role assignments.
+# ---------------------------------------------------------------------------
+removed {
+  from = module.rbac_bootstrap.azurerm_role_assignment.bootstrap
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.acr.azurerm_role_assignment.acr_push_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.appconfig.azurerm_role_assignment.appconfig_owner_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.keyvault.azurerm_role_assignment.kv_admin_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.cosmosdb.azurerm_cosmosdb_sql_role_assignment.deployer_data_contributor
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -10,7 +10,7 @@ project_name = "fastapi-azure-app"
 
 # Optional override for deployment principal object ID used by bootstrap/deployer RBAC.
 # Set to null to use the currently authenticated principal.
-deployment_principal_object_id = "cd7ca1e6-67f4-4120-b3a2-615de398cc6a"
+deployment_principal_object_id = null
 
 # RBAC bootstrap sequencing (operator runbook):
 # 1. Run scripts/bootstrap_pipeline_rbac.sh as a privileged operator to grant

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -8,13 +8,8 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  app_name                = "bankapi"
-  unique_suffix           = substr(data.azurerm_client_config.current.subscription_id, 27, 6)
-  project_repository_path = "project/${var.project_name}"
-  deployment_principal_object_id = coalesce(
-    var.deployment_principal_object_id,
-    data.azurerm_client_config.current.object_id,
-  )
+  app_name      = "bankapi"
+  unique_suffix = substr(data.azurerm_client_config.current.subscription_id, 27, 6)
 
   common_tags = {
     environment = var.env
@@ -29,19 +24,6 @@ resource "azurerm_resource_group" "main" {
   name     = "rg-${local.app_name}-${var.env}"
   location = var.location
   tags     = local.common_tags
-}
-
-# ---------------------------------------------------------------------------
-# RBAC bootstrap for deployment principal (management-plane role assignment rights)
-# ---------------------------------------------------------------------------
-module "rbac_bootstrap" {
-  source = "../../modules/rbac_bootstrap"
-
-  enabled                          = var.rbac_bootstrap_enabled
-  resource_group_id                = azurerm_resource_group.main.id
-  deployment_principal_object_id   = local.deployment_principal_object_id
-  role_definition_names            = var.rbac_bootstrap_role_definition_names
-  skip_service_principal_aad_check = var.rbac_bootstrap_skip_sp_aad_check
 }
 
 # ---------------------------------------------------------------------------
@@ -80,17 +62,12 @@ module "monitoring" {
 }
 
 # ---------------------------------------------------------------------------
-# Cosmos DB — account, database, container + deployer RBAC
+# Cosmos DB — account, database, container + app UAMI RBAC
 # Provisioned throughput (enable_serverless = false) for predictable prod perf.
-# Depends on rbac_bootstrap so the deployment principal holds the Contributor
-# role (needed for Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write)
-# before the Cosmos DB SQL role assignment is attempted.
 # ---------------------------------------------------------------------------
 
 module "cosmosdb" {
   source = "../../modules/cosmosdb"
-
-  depends_on = [module.rbac_bootstrap]
 
   resource_group_name      = azurerm_resource_group.main.name
   location                 = azurerm_resource_group.main.location
@@ -99,7 +76,6 @@ module "cosmosdb" {
   unique_suffix            = local.unique_suffix
   enable_serverless        = var.enable_serverless
   db_name                  = var.cosmos_db_name
-  deployer_object_id       = local.deployment_principal_object_id
   app_uami_principal_id    = module.keyvault.uami_principal_id
   assign_app_cosmosdb_role = true
   tags                     = local.common_tags
@@ -111,15 +87,12 @@ module "cosmosdb" {
 module "keyvault" {
   source = "../../modules/keyvault"
 
-  depends_on = [module.rbac_bootstrap]
-
   resource_group_name            = azurerm_resource_group.main.name
   location                       = azurerm_resource_group.main.location
   app_name                       = local.app_name
   env                            = var.env
   unique_suffix                  = local.unique_suffix
   tenant_id                      = data.azurerm_client_config.current.tenant_id
-  deployer_object_id             = local.deployment_principal_object_id
   kv_sku                         = var.kv_sku
   kv_soft_delete_retention_days  = var.kv_soft_delete_retention_days
   purge_protection_enabled       = var.purge_protection_enabled
@@ -135,13 +108,10 @@ module "keyvault" {
 module "appconfig" {
   source = "../../modules/appconfig"
 
-  depends_on = [module.rbac_bootstrap]
-
   resource_group_name        = azurerm_resource_group.main.name
   location                   = azurerm_resource_group.main.location
   app_name                   = local.app_name
   env                        = var.env
-  deployer_object_id         = local.deployment_principal_object_id
   app_identity_principal_id  = module.keyvault.uami_principal_id
   app_config_sku             = var.app_config_sku
   soft_delete_retention_days = var.app_config_soft_delete_days
@@ -154,16 +124,14 @@ module "appconfig" {
 module "acr" {
   source = "../../modules/acr"
 
-  resource_group_name     = azurerm_resource_group.main.name
-  location                = azurerm_resource_group.main.location
-  app_name                = local.app_name
-  env                     = var.env
-  unique_suffix           = local.unique_suffix
-  acr_sku                 = var.acr_sku
-  uami_principal_id       = module.keyvault.uami_principal_id
-  deployer_object_id      = local.deployment_principal_object_id
-  project_repository_path = local.project_repository_path
-  tags                    = local.common_tags
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  app_name            = local.app_name
+  env                 = var.env
+  unique_suffix       = local.unique_suffix
+  acr_sku             = var.acr_sku
+  uami_principal_id   = module.keyvault.uami_principal_id
+  tags                = local.common_tags
 
   # UAMI must exist before we can assign the AcrPull role
   depends_on = [module.keyvault]
@@ -222,4 +190,49 @@ module "container_app" {
   smtp_timeout_seconds = var.smtp_timeout_seconds
 
   tags = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# State migration: deployer RBAC is now script-managed.
+# Remove legacy deployer assignments from Terraform state without deleting
+# live Azure role assignments.
+# ---------------------------------------------------------------------------
+removed {
+  from = module.rbac_bootstrap.azurerm_role_assignment.bootstrap
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.acr.azurerm_role_assignment.acr_push_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.appconfig.azurerm_role_assignment.appconfig_owner_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.keyvault.azurerm_role_assignment.kv_admin_deployer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.cosmosdb.azurerm_cosmosdb_sql_role_assignment.deployer_data_contributor
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/infra/modules/acr/main.tf
+++ b/infra/modules/acr/main.tf
@@ -44,24 +44,6 @@ resource "azapi_update_resource" "acr_role_assignment_mode" {
   }
 }
 
-locals {
-  deployer_repository_condition_default = <<-EOT
-  (
-    (
-      !(ActionMatches{'Microsoft.ContainerRegistry/registries/pull/read'})
-      &&
-      !(ActionMatches{'Microsoft.ContainerRegistry/registries/push/write'})
-    )
-    ||
-    (
-      @Resource[Microsoft.ContainerRegistry/registries/repositories:Name] StringLike '${var.project_repository_path}'
-      ||
-      @Resource[Microsoft.ContainerRegistry/registries/repositories:Name] StringLike '${var.project_repository_path}/*'
-    )
-  )
-  EOT
-}
-
 # ---------------------------------------------------------------------------
 # RBAC — UAMI → AcrPull
 # Allows the Container App's managed identity to pull images at runtime
@@ -98,39 +80,3 @@ resource "azurerm_role_assignment" "acr_pull_uami" {
   }
 }
 
-# ---------------------------------------------------------------------------
-# RBAC — deploying principal → AcrPush
-# Allows the CI/CD service-principal pipeline to push images via:
-#   az acr login --name <acr_name>
-#   docker push <acr_login_server>/bank-api:<tag>
-# The deployer is a service principal in CI/CD; skip_service_principal_aad_check
-# prevents the provider from polling AAD for propagation, which avoids
-# intermittent 400/403 errors when the identity was recently created or
-# re-granted.
-# ---------------------------------------------------------------------------
-resource "azurerm_role_assignment" "acr_push_deployer" {
-  depends_on = [azapi_update_resource.acr_role_assignment_mode]
-
-  scope                = azurerm_container_registry.acr.id
-  role_definition_name = "AcrPush"
-  principal_id         = var.deployer_object_id
-
-  condition_version = var.enforce_project_repository_abac ? "2.0" : null
-  condition = var.enforce_project_repository_abac ? coalesce(
-    var.deployer_repository_condition,
-    local.deployer_repository_condition_default,
-  ) : null
-
-  skip_service_principal_aad_check = true
-
-  lifecycle {
-    ignore_changes = [
-      # Provider-only flag; Azure never persists it — ignore to prevent
-      # perpetual "update" cycles after provider version changes.
-      skip_service_principal_aad_check,
-      # Computed alongside role_definition_name; may vary across provider
-      # versions without a real config change.
-      role_definition_id,
-    ]
-  }
-}

--- a/infra/modules/acr/tests/unit.tftest.hcl
+++ b/infra/modules/acr/tests/unit.tftest.hcl
@@ -15,8 +15,6 @@ variables {
   unique_suffix                    = "abcdef"
   acr_sku                          = "Basic"
   uami_principal_id                = "00000000-0000-0000-0000-000000000111"
-  deployer_object_id               = "00000000-0000-0000-0000-000000000222"
-  project_repository_path          = "project/fastapi-azure-app"
   enforce_acr_role_assignment_mode = false
   tags                             = {}
 }
@@ -36,28 +34,5 @@ run "uami_has_acr_pull_role" {
   assert {
     condition     = azurerm_role_assignment.acr_pull_uami.role_definition_name == "AcrPull"
     error_message = "The application identity must receive the AcrPull role."
-  }
-}
-
-run "deployer_has_acr_push_role" {
-  command = plan
-
-  assert {
-    condition     = azurerm_role_assignment.acr_push_deployer.role_definition_name == "AcrPush"
-    error_message = "The deployer must receive the AcrPush role."
-  }
-}
-
-run "deployer_acr_push_is_abac_scoped_to_project_repository" {
-  command = plan
-
-  assert {
-    condition     = azurerm_role_assignment.acr_push_deployer.condition_version == "2.0"
-    error_message = "The deployer AcrPush role assignment must use condition_version 2.0 when ABAC enforcement is enabled."
-  }
-
-  assert {
-    condition     = can(regex("project/fastapi-azure-app", azurerm_role_assignment.acr_push_deployer.condition))
-    error_message = "The deployer AcrPush ABAC condition must restrict access to the configured project repository path."
   }
 }

--- a/infra/modules/acr/variables.tf
+++ b/infra/modules/acr/variables.tf
@@ -69,32 +69,6 @@ variable "uami_principal_id" {
   }
 }
 
-variable "deployer_object_id" {
-  description = "Object ID of the deploying principal to grant AcrPush (CI/CD or developer)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[0-9a-fA-F-]{36}$", var.deployer_object_id))
-    error_message = "deployer_object_id must be a valid GUID."
-  }
-}
-
-variable "project_repository_path" {
-  description = "Repository path prefix enforced for deployer push/pull access (for example: project/fastapi-azure-app)."
-  type        = string
-
-  validation {
-    condition     = can(regex("^project/[a-z0-9][a-z0-9._-]*$", var.project_repository_path))
-    error_message = "project_repository_path must match 'project/<project-name>' using lowercase letters, digits, dots, underscores, or hyphens."
-  }
-}
-
-variable "enforce_project_repository_abac" {
-  description = "When true, applies an ABAC condition to the deployer AcrPush assignment so access is limited to project_repository_path."
-  type        = bool
-  default     = true
-}
-
 variable "enforce_acr_role_assignment_mode" {
   description = "When true, configures the ACR registry roleAssignmentMode property via ARM to ensure ABAC repository permissions are active."
   type        = bool
@@ -110,12 +84,6 @@ variable "acr_role_assignment_mode" {
     condition     = contains(["AbacRepositoryPermissions", "LegacyRegistryPermissions"], var.acr_role_assignment_mode)
     error_message = "acr_role_assignment_mode must be AbacRepositoryPermissions or LegacyRegistryPermissions."
   }
-}
-
-variable "deployer_repository_condition" {
-  description = "Optional ABAC condition expression override (condition_version 2.0) for the deployer AcrPush role assignment. Leave null to use the module default project path condition."
-  type        = string
-  default     = null
 }
 
 variable "tags" {

--- a/infra/modules/appconfig/main.tf
+++ b/infra/modules/appconfig/main.tf
@@ -3,15 +3,6 @@
 # Provisions: Azure App Configuration + RBAC + seed key-values
 # ===========================================================================
 
-terraform {
-  required_providers {
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.11"
-    }
-  }
-}
-
 resource "azurerm_app_configuration" "appconfig" {
   name                       = "appcs-${var.app_name}-${var.env}"
   location                   = var.location
@@ -20,39 +11,6 @@ resource "azurerm_app_configuration" "appconfig" {
   soft_delete_retention_days = var.soft_delete_retention_days
 
   tags = var.tags
-}
-
-# ---------------------------------------------------------------------------
-# RBAC — deploying principal → Data Owner (write key-values via Terraform)
-# The deployer is a CI/CD service principal; skip_service_principal_aad_check
-# prevents the provider from polling AAD for propagation, which avoids
-# intermittent 400/403 errors when the identity was recently created or
-# re-granted.
-# ---------------------------------------------------------------------------
-resource "azurerm_role_assignment" "appconfig_owner_deployer" {
-  scope                = azurerm_app_configuration.appconfig.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = var.deployer_object_id
-
-  skip_service_principal_aad_check = true
-
-  lifecycle {
-    ignore_changes = [
-      # Provider-only flag; Azure never persists it — ignore to prevent
-      # perpetual "update" cycles after provider version changes.
-      skip_service_principal_aad_check,
-      # Computed alongside role_definition_name; may vary across provider
-      # versions without a real config change.
-      role_definition_id,
-    ]
-  }
-}
-
-# RBAC propagation in App Configuration data plane can lag immediately after
-# role-assignment create. Delay key reads/writes until permissions are effective.
-resource "time_sleep" "wait_for_deployer_data_owner_rbac" {
-  depends_on      = [azurerm_role_assignment.appconfig_owner_deployer]
-  create_duration = "${var.rbac_propagation_wait_seconds}s"
 }
 
 # ---------------------------------------------------------------------------
@@ -81,8 +39,6 @@ resource "azurerm_app_configuration_key" "environment" {
   key                    = "app:environment"
   value                  = var.env
   label                  = var.env
-
-  depends_on = [time_sleep.wait_for_deployer_data_owner_rbac]
 }
 
 resource "azurerm_app_configuration_key" "app_name" {
@@ -90,6 +46,4 @@ resource "azurerm_app_configuration_key" "app_name" {
   key                    = "app:name"
   value                  = var.app_name
   label                  = var.env
-
-  depends_on = [time_sleep.wait_for_deployer_data_owner_rbac]
 }

--- a/infra/modules/appconfig/tests/unit.tftest.hcl
+++ b/infra/modules/appconfig/tests/unit.tftest.hcl
@@ -14,7 +14,6 @@ variables {
   location                   = "eastus"
   app_name                   = "bankapi"
   env                        = "dev"
-  deployer_object_id         = "00000000-0000-0000-0000-000000000111"
   app_identity_principal_id  = "00000000-0000-0000-0000-000000000222"
   app_config_sku             = "standard"
   soft_delete_retention_days = 7
@@ -27,15 +26,6 @@ run "appconfig_name_matches_convention" {
   assert {
     condition     = azurerm_app_configuration.appconfig.name == "appcs-bankapi-dev"
     error_message = "App Configuration name must follow the appcs-<app>-<env> convention."
-  }
-}
-
-run "deployer_has_data_owner_role" {
-  command = plan
-
-  assert {
-    condition     = azurerm_role_assignment.appconfig_owner_deployer.role_definition_name == "App Configuration Data Owner"
-    error_message = "The deployer must receive the App Configuration Data Owner role."
   }
 }
 
@@ -54,14 +44,5 @@ run "app_reader_assignment_skips_aad_check" {
   assert {
     condition     = azurerm_role_assignment.appconfig_reader_app.skip_service_principal_aad_check == true
     error_message = "App Configuration Data Reader assignment must set skip_service_principal_aad_check = true to avoid UAMI propagation timing failures."
-  }
-}
-
-run "rbac_propagation_wait_default" {
-  command = plan
-
-  assert {
-    condition     = time_sleep.wait_for_deployer_data_owner_rbac.create_duration == "90s"
-    error_message = "App Configuration module must wait for deployer RBAC propagation before key operations."
   }
 }

--- a/infra/modules/appconfig/variables.tf
+++ b/infra/modules/appconfig/variables.tf
@@ -38,16 +38,6 @@ variable "env" {
   }
 }
 
-variable "deployer_object_id" {
-  description = "Object ID of the principal running Terraform (gets Data Owner role)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[0-9a-fA-F-]{36}$", var.deployer_object_id))
-    error_message = "deployer_object_id must be a valid GUID."
-  }
-}
-
 variable "app_identity_principal_id" {
   description = "Principal ID of the UAMI that the Container App uses (gets Data Reader role)"
   type        = string
@@ -86,13 +76,3 @@ variable "tags" {
   default     = {}
 }
 
-variable "rbac_propagation_wait_seconds" {
-  description = "Seconds to wait after deployer data-owner role assignment before App Configuration key operations."
-  type        = number
-  default     = 90
-
-  validation {
-    condition     = var.rbac_propagation_wait_seconds >= 0 && var.rbac_propagation_wait_seconds <= 600
-    error_message = "rbac_propagation_wait_seconds must be between 0 and 600."
-  }
-}

--- a/infra/modules/cosmosdb/main.tf
+++ b/infra/modules/cosmosdb/main.tf
@@ -130,25 +130,6 @@ resource "azurerm_cosmosdb_sql_container" "user_profiles" {
   }
 }
 
-# ── RBAC: deployer → Cosmos DB Built-in Data Contributor ─────────────────────
-# Grants the principal running Terraform (your local machine / CI pipeline)
-# full data-plane read/write access so you can query Cosmos from your
-# workstation using az CLI or the Azure Portal Data Explorer.
-
-resource "azurerm_cosmosdb_sql_role_assignment" "deployer_data_contributor" {
-  resource_group_name = var.resource_group_name
-  account_name        = azurerm_cosmosdb_account.cosmos.name
-
-  # Built-in role: 00000000-0000-0000-0000-000000000002 = Data Contributor
-  role_definition_id = "${azurerm_cosmosdb_account.cosmos.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-  principal_id       = var.deployer_object_id
-  scope              = azurerm_cosmosdb_account.cosmos.id
-
-  lifecycle {
-    ignore_changes = [role_definition_id]
-  }
-}
-
 resource "azurerm_cosmosdb_sql_role_assignment" "app_data_contributor" {
   count = var.assign_app_cosmosdb_role ? 1 : 0
 

--- a/infra/modules/cosmosdb/variables.tf
+++ b/infra/modules/cosmosdb/variables.tf
@@ -74,11 +74,6 @@ variable "max_throughput" {
   default     = 1000
 }
 
-variable "deployer_object_id" {
-  description = "Object ID of the principal running Terraform; granted Cosmos DB Built-in Data Contributor for local dev access"
-  type        = string
-}
-
 variable "app_uami_principal_id" {
   description = "Principal ID of the Container App user-assigned managed identity; when set, receives Cosmos DB Built-in Data Contributor at account scope"
   type        = string

--- a/infra/modules/keyvault/main.tf
+++ b/infra/modules/keyvault/main.tf
@@ -3,15 +3,6 @@
 # Provisions: User-Assigned Managed Identity + Key Vault (RBAC mode) + Secrets
 # ===========================================================================
 
-terraform {
-  required_providers {
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.11"
-    }
-  }
-}
-
 # ---------------------------------------------------------------------------
 # User-Assigned Managed Identity
 # Created here so the Container App module can attach it without a circular
@@ -51,40 +42,6 @@ resource "azurerm_key_vault" "kv" {
 }
 
 # ---------------------------------------------------------------------------
-# RBAC — deploying principal → Key Vault Administrator
-# Required so Terraform can write secrets.
-# The deployer is a CI/CD service principal; skip_service_principal_aad_check
-# prevents the provider from polling AAD for propagation, which avoids
-# intermittent 400/403 errors when the identity was recently created or
-# re-granted.
-# ---------------------------------------------------------------------------
-resource "azurerm_role_assignment" "kv_admin_deployer" {
-  scope                = azurerm_key_vault.kv.id
-  role_definition_name = "Key Vault Administrator"
-  principal_id         = var.deployer_object_id
-
-  skip_service_principal_aad_check = true
-
-  lifecycle {
-    ignore_changes = [
-      # Provider-only flag; Azure never persists it — ignore to prevent
-      # perpetual "update" cycles after provider version changes.
-      skip_service_principal_aad_check,
-      # Computed alongside role_definition_name; may vary across provider
-      # versions without a real config change.
-      role_definition_id,
-    ]
-  }
-}
-
-# Key Vault data-plane RBAC can take time to propagate after role assignment.
-# Delay secret reads/writes to avoid transient 403 ForbiddenByRbac failures.
-resource "time_sleep" "wait_for_kv_admin_rbac" {
-  depends_on      = [azurerm_role_assignment.kv_admin_deployer]
-  create_duration = "${var.rbac_propagation_wait_seconds}s"
-}
-
-# ---------------------------------------------------------------------------
 # RBAC — UAMI → Key Vault Secrets User (read-only at runtime)
 # ---------------------------------------------------------------------------
 resource "azurerm_role_assignment" "kv_secrets_user_app" {
@@ -118,7 +75,6 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
   # Wait for deployer to have write access AND the UAMI read role to be assigned
   # so both the secret write and the runtime read path are ready atomically.
   depends_on = [
-    time_sleep.wait_for_kv_admin_rbac,
     azurerm_role_assignment.kv_secrets_user_app,
   ]
 
@@ -138,7 +94,6 @@ resource "azurerm_key_vault_secret" "jwt_secret_key" {
   tags = var.tags
 
   depends_on = [
-    time_sleep.wait_for_kv_admin_rbac,
     azurerm_role_assignment.kv_secrets_user_app,
   ]
 
@@ -158,7 +113,6 @@ resource "azurerm_key_vault_secret" "smtp_password" {
   tags = var.tags
 
   depends_on = [
-    time_sleep.wait_for_kv_admin_rbac,
     azurerm_role_assignment.kv_secrets_user_app,
   ]
 

--- a/infra/modules/keyvault/tests/unit.tftest.hcl
+++ b/infra/modules/keyvault/tests/unit.tftest.hcl
@@ -21,8 +21,6 @@ mock_provider "azurerm" {
   }
 }
 
-mock_provider "time" {}
-
 variables {
   resource_group_name            = "rg-test"
   location                       = "eastus"
@@ -30,7 +28,6 @@ variables {
   env                            = "dev"
   unique_suffix                  = "abcdef"
   tenant_id                      = "00000000-0000-0000-0000-000000000001"
-  deployer_object_id             = "00000000-0000-0000-0000-000000000002"
   app_insights_connection_string = "InstrumentationKey=mock"
   jwt_secret_key                 = "mock-jwt-secret"
   smtp_password                  = "mock-smtp-password"
@@ -73,29 +70,11 @@ run "key_vault_uses_rbac_authorization" {
   }
 }
 
-run "kv_admin_deployer_skips_aad_check" {
-  command = plan
-
-  assert {
-    condition     = azurerm_role_assignment.kv_admin_deployer.skip_service_principal_aad_check == true
-    error_message = "kv_admin_deployer role assignment must set skip_service_principal_aad_check = true for CI/CD service principal deployers to avoid AAD propagation delays."
-  }
-}
-
 run "kv_runtime_reader_skips_aad_check" {
   command = plan
 
   assert {
     condition     = azurerm_role_assignment.kv_secrets_user_app.skip_service_principal_aad_check == true
     error_message = "kv_secrets_user_app role assignment must set skip_service_principal_aad_check = true to avoid UAMI propagation timing failures."
-  }
-}
-
-run "kv_rbac_propagation_wait_default" {
-  command = plan
-
-  assert {
-    condition     = time_sleep.wait_for_kv_admin_rbac.create_duration == "90s"
-    error_message = "Key Vault module must wait for deployer RBAC propagation before secret operations."
   }
 }

--- a/infra/modules/keyvault/variables.tf
+++ b/infra/modules/keyvault/variables.tf
@@ -43,16 +43,6 @@ variable "tenant_id" {
   }
 }
 
-variable "deployer_object_id" {
-  description = "Object ID of the principal running Terraform (needs KV Administrator)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[0-9a-fA-F-]{36}$", var.deployer_object_id))
-    error_message = "deployer_object_id must be a valid GUID."
-  }
-}
-
 variable "kv_sku" {
   description = "Key Vault SKU: standard | premium"
   type        = string
@@ -120,13 +110,3 @@ variable "tags" {
   default     = {}
 }
 
-variable "rbac_propagation_wait_seconds" {
-  description = "Seconds to wait after deployer Key Vault Administrator role assignment before secret operations."
-  type        = number
-  default     = 90
-
-  validation {
-    condition     = var.rbac_propagation_wait_seconds >= 0 && var.rbac_propagation_wait_seconds <= 600
-    error_message = "rbac_propagation_wait_seconds must be between 0 and 600."
-  }
-}

--- a/pipelines/tf-infra-apply.yml
+++ b/pipelines/tf-infra-apply.yml
@@ -168,6 +168,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           - task: AzureCLI@2
@@ -185,6 +186,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           - task: AzureCLI@2
@@ -202,6 +204,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Agent.TempDirectory)/plan-preview.txt"
 
@@ -324,6 +327,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       terraform init -input=false
 
                 # Re-plan fresh (guards against state drift since PlanPreview ran)
@@ -342,6 +346,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       echo "Re-running plan to guard against state drift ..."
                       terraform plan -out=tfplan -input=false -no-color -var-file=terraform.tfvars
 
@@ -360,6 +365,7 @@ stages:
                       export ARM_TENANT_ID="$tenantId"
                       export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                       export ARM_USE_OIDC=true
+                          export ARM_USE_AZUREAD=true
                       terraform apply -auto-approve -input=false tfplan
 
                 - task: AzureCLI@2

--- a/pipelines/tf-infra-plan.yml
+++ b/pipelines/tf-infra-plan.yml
@@ -174,6 +174,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           # ── Validate ──────────────────────────────────────────────────────
@@ -192,6 +193,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           # ── Plan ──────────────────────────────────────────────────────────
@@ -210,6 +212,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Build.ArtifactStagingDirectory)/plan-dev.txt"
 
@@ -377,6 +380,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform init -input=false
 
           - task: AzureCLI@2
@@ -394,6 +398,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform validate -no-color
 
           - task: AzureCLI@2
@@ -411,6 +416,7 @@ stages:
                 export ARM_TENANT_ID="$tenantId"
                 export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
                 export ARM_USE_OIDC=true
+                export ARM_USE_AZUREAD=true
                 terraform plan -no-color -input=false -var-file=terraform.tfvars \
                   2>&1 | tee "$(Build.ArtifactStagingDirectory)/plan-prod.txt"
 

--- a/scripts/bootstrap_pipeline_rbac.sh
+++ b/scripts/bootstrap_pipeline_rbac.sh
@@ -3,10 +3,98 @@ set -euo pipefail
 
 # Manual prerequisite bootstrap for Terraform pipeline identity.
 # Run this with a privileged operator identity (Owner or User Access Administrator)
-# before enabling rbac_bootstrap in terraform.tfvars.
+# before running infra apply workflows.
 
-readonly PIPELINE_CLIENT_ID="05baf6a1-cae6-442a-94d6-f0d1f64b61f4"
-readonly PIPELINE_OBJECT_ID="cd7ca1e6-67f4-4120-b3a2-615de398cc6a"
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id <service-principal-client-id> \
+    [--object-id <service-principal-object-id>] \
+    [--subscription-id <subscription-id>] \
+    [--resource-group <resource-group-name>] \
+    [--acr-name <acr-name>] \
+    [--keyvault-name <keyvault-name>] \
+    [--appconfig-name <appconfig-name>]
+
+Description:
+  Idempotently assigns required roles to the Terraform/GitHub federated deployer identity.
+  Always grants subscription-scope Contributor + ABAC-constrained User Access Administrator.
+  Optionally grants resource-scope roles for existing resources:
+    - ACR: AcrPush
+    - Key Vault: Key Vault Administrator
+    - App Configuration: App Configuration Data Owner
+
+Examples:
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id 05baf6a1-cae6-442a-94d6-f0d1f64b61f4 \
+    --object-id cd7ca1e6-67f4-4120-b3a2-615de398cc6a
+
+  scripts/bootstrap_pipeline_rbac.sh \
+    --client-id 05baf6a1-cae6-442a-94d6-f0d1f64b61f4 \
+    --object-id cd7ca1e6-67f4-4120-b3a2-615de398cc6a \
+    --resource-group rg-bankapi-dev \
+    --acr-name acrbankapidevc8775a \
+    --keyvault-name kv-bankapi-dev-c8775a \
+    --appconfig-name appcs-bankapi-dev
+EOF
+}
+
+PIPELINE_CLIENT_ID=""
+PIPELINE_OBJECT_ID=""
+SUBSCRIPTION_ID=""
+RESOURCE_GROUP=""
+ACR_NAME=""
+KEYVAULT_NAME=""
+APPCONFIG_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --client-id)
+      PIPELINE_CLIENT_ID="$2"
+      shift 2
+      ;;
+    --object-id)
+      PIPELINE_OBJECT_ID="$2"
+      shift 2
+      ;;
+    --subscription-id)
+      SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    --resource-group)
+      RESOURCE_GROUP="$2"
+      shift 2
+      ;;
+    --acr-name)
+      ACR_NAME="$2"
+      shift 2
+      ;;
+    --keyvault-name)
+      KEYVAULT_NAME="$2"
+      shift 2
+      ;;
+    --appconfig-name)
+      APPCONFIG_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${PIPELINE_CLIENT_ID}" ]]; then
+  echo "--client-id is required." >&2
+  usage
+  exit 1
+fi
 
 readonly CONTRIBUTOR_ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"
 readonly UAA_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
@@ -22,7 +110,9 @@ if ! command -v az >/dev/null 2>&1; then
   exit 1
 fi
 
-SUBSCRIPTION_ID="${1:-$(az account show --query id -o tsv)}"
+if [[ -z "${SUBSCRIPTION_ID}" ]]; then
+  SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+fi
 SUBSCRIPTION_SCOPE="/subscriptions/${SUBSCRIPTION_ID}"
 
 readonly UAA_ABAC_CONDITION="(
@@ -46,6 +136,15 @@ readonly UAA_ABAC_CONDITION="(
 
 echo "Using subscription: ${SUBSCRIPTION_ID}"
 echo "Target principal client id: ${PIPELINE_CLIENT_ID}"
+resolved_oid="$(az ad sp show --id "${PIPELINE_CLIENT_ID}" --query id -o tsv)"
+if [[ -z "${PIPELINE_OBJECT_ID}" ]]; then
+  PIPELINE_OBJECT_ID="${resolved_oid}"
+  echo "Resolved principal object id from client id: ${PIPELINE_OBJECT_ID}"
+elif [[ "${resolved_oid}" != "${PIPELINE_OBJECT_ID}" ]]; then
+  echo "WARNING: --client-id resolves to object id ${resolved_oid}, but --object-id was ${PIPELINE_OBJECT_ID}." >&2
+  echo "WARNING: Continuing with resolved service principal object id: ${resolved_oid}" >&2
+  PIPELINE_OBJECT_ID="${resolved_oid}"
+fi
 echo "Target principal object id: ${PIPELINE_OBJECT_ID}"
 echo
 
@@ -98,6 +197,62 @@ else
     --only-show-errors \
     1>/dev/null
   echo "User Access Administrator assignment created with ABAC condition."
+fi
+
+assignment_exists_for_scope() {
+  local role_name="$1"
+  local scope="$2"
+  local query="[?roleDefinitionName=='${role_name}' && scope=='${scope}'] | length(@)"
+  local count
+  count="$(az role assignment list \
+    --assignee-object-id "${PIPELINE_OBJECT_ID}" \
+    --scope "${scope}" \
+    --query "${query}" \
+    -o tsv)"
+  [[ "${count:-0}" != "0" ]]
+}
+
+ensure_role_assignment() {
+  local role_name="$1"
+  local scope="$2"
+
+  if assignment_exists_for_scope "${role_name}" "${scope}"; then
+    echo "${role_name} already assigned at ${scope}; skipping create."
+    return
+  fi
+
+  echo "Assigning ${role_name} at ${scope}..."
+  az role assignment create \
+    --assignee-object-id "${PIPELINE_OBJECT_ID}" \
+    --assignee-principal-type ServicePrincipal \
+    --role "${role_name}" \
+    --scope "${scope}" \
+    --only-show-errors \
+    1>/dev/null
+  echo "${role_name} assignment created at ${scope}."
+}
+
+# Optional resource-scope grants to recover from stale/missing deployer RBAC.
+if [[ -n "${RESOURCE_GROUP}" ]]; then
+  resource_group_scope="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
+
+  if [[ -n "${ACR_NAME}" ]]; then
+    acr_scope="${resource_group_scope}/providers/Microsoft.ContainerRegistry/registries/${ACR_NAME}"
+    ensure_role_assignment "AcrPush" "${acr_scope}"
+  fi
+
+  if [[ -n "${KEYVAULT_NAME}" ]]; then
+    kv_scope="${resource_group_scope}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}"
+    ensure_role_assignment "Key Vault Administrator" "${kv_scope}"
+  fi
+
+  if [[ -n "${APPCONFIG_NAME}" ]]; then
+    appconfig_scope="${resource_group_scope}/providers/Microsoft.AppConfiguration/configurationStores/${APPCONFIG_NAME}"
+    ensure_role_assignment "App Configuration Data Owner" "${appconfig_scope}"
+  fi
+elif [[ -n "${ACR_NAME}" || -n "${KEYVAULT_NAME}" || -n "${APPCONFIG_NAME}" ]]; then
+  echo "ERROR: --resource-group is required when using --acr-name, --keyvault-name, or --appconfig-name." >&2
+  exit 1
 fi
 
 echo


### PR DESCRIPTION
## Summary
Shifted deployer RBAC ownership out of Terraform and into the bootstrap script workflow.

## Why
Terraform and manual/script bootstrap were both managing deployer role assignments, causing ownership conflicts and duplicate assignment errors (`RoleAssignmentExists`).

## Changes
- Removed Terraform-managed deployer RBAC assignments from modules:
  - App Configuration deployer Data Owner
  - Key Vault deployer Administrator
  - ACR deployer AcrPush
  - Cosmos deployer data contributor
- Kept runtime app identity RBAC in Terraform (UAMI runtime access remains managed).
- Removed deployer RBAC wiring from env root modules (`dev` and `prod`).
- Added `removed` blocks with `destroy = false` in `dev` and `prod` roots for safe state detachment of legacy deployer RBAC resources.
- Updated module variable contracts and tftest files to align with the new ownership model.

## Validation
- `terraform -chdir=infra/environments/dev validate` ✅
- `terraform -chdir=infra/environments/prod validate` ✅

## Operational Notes
- Deployer identity RBAC must now be applied via `scripts/bootstrap_pipeline_rbac.sh`.
- This change intentionally keeps deployer role assignments out of Terraform to prevent ownership contention.