### PR TITLE
fix: harden Terraform output handling for image build workflow

### DIFF
--- a/.github/workflows/main-dev-release.yml
+++ b/.github/workflows/main-dev-release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
 
       - name: Azure Login (dev)
         uses: azure/login@v2
@@ -146,6 +147,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
 
       - name: Azure Login (dev)
         uses: azure/login@v2
@@ -180,9 +182,25 @@ jobs:
         id: tf-outputs
         working-directory: infra/environments/dev
         run: |
-          echo "resource_group_name=$(terraform output -raw resource_group_name)" >> "$GITHUB_OUTPUT"
-          echo "container_app_name=$(terraform output -raw container_app_name)" >> "$GITHUB_OUTPUT"
-          echo "acr_login_server=$(terraform output -raw acr_login_server)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          resource_group_name="$(terraform output -raw resource_group_name)"
+          container_app_name="$(terraform output -raw container_app_name)"
+          acr_login_server="$(terraform output -raw acr_login_server)"
+
+          if [[ -z "${resource_group_name}" || -z "${container_app_name}" || -z "${acr_login_server}" ]]; then
+            echo "::error::Terraform outputs contain empty values. Expected resource_group_name, container_app_name, and acr_login_server."
+            exit 1
+          fi
+
+          if [[ ! "${acr_login_server}" =~ ^[a-z0-9][a-z0-9-]*\.azurecr\.io$ ]]; then
+            echo "::error::Invalid acr_login_server output '${acr_login_server}'. Expected '<acr-name>.azurecr.io'."
+            exit 1
+          fi
+
+          echo "resource_group_name=${resource_group_name}" >> "$GITHUB_OUTPUT"
+          echo "container_app_name=${container_app_name}" >> "$GITHUB_OUTPUT"
+          echo "acr_login_server=${acr_login_server}" >> "$GITHUB_OUTPUT"
 
   build_image:
     name: Build Python and Publish Image


### PR DESCRIPTION
## Summary
Fixes a GitHub Actions failure in **Build Python and Publish Image** where Docker received an invalid image reference because Terraform error text polluted the registry output.

## Root Cause
`hashicorp/setup-terraform` wrapper output could inject `::error::...` text into `terraform output -raw` capture paths, which then flowed into `container_registry_url` and produced invalid Docker tags.

## Changes
- In `.github/workflows/main-dev-release.yml`:
  - Set `terraform_wrapper: false` in both `Setup Terraform` steps.
  - Hardened `Capture Terraform outputs` step:
    - `set -euo pipefail`
    - Capture outputs into variables before writing to `GITHUB_OUTPUT`
    - Validate non-empty `resource_group_name`, `container_app_name`, `acr_login_server`
    - Validate `acr_login_server` matches `<acr-name>.azurecr.io`
    - Fail fast with explicit `::error::` if invalid

## Validation
- Workflow permission-scope check: passed.
- SHA truncation consistency (`workflow-build-v1.0.0.yml` vs `cd.yml`): passed (`12` chars).

## Risk / Rollback
- Low risk: only workflow YAML logic changed.
- Rollback: revert commit `a51a8ec`.